### PR TITLE
feat(core-manager): add the core control plane and the additive IPC v2 wire (PR-A + PR-B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,6 +1958,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "zerocopy",
 ]
 
 [[package]]

--- a/crates/nyanpasu-core-manager/Cargo.toml
+++ b/crates/nyanpasu-core-manager/Cargo.toml
@@ -5,10 +5,6 @@ edition.workspace = true
 repository.workspace = true
 license.workspace = true
 
-[features]
-default = []
-test-hooks = []
-
 [[bin]]
 doc = false
 name = "nyanpasu-fake-core"
@@ -20,16 +16,13 @@ name = "nyanpasu-manager-host"
 path = "tests/helpers/manager_host.rs"
 
 [dependencies]
+nyanpasu-core-metadata = { path = "../nyanpasu-core-metadata" }
+nyanpasu-utils = { path = "../nyanpasu-utils", default-features = false, features = ["process"] }
+
 camino = { version = "1.1", features = ["serde1"] }
 chrono.workspace = true
 clash-api = { path = "../clash-api" }
 enumset = "1"
-nyanpasu-core-metadata = { path = "../nyanpasu-core-metadata" }
-nyanpasu-utils = {
-  path = "../nyanpasu-utils",
-  default-features = false,
-  features = ["process"]
-}
 parking_lot.workspace = true
 schemars = { version = "1", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
@@ -40,7 +33,12 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
+zerocopy = { version = "0.8", features = ["derive", "simd"] }
 
 [dev-dependencies]
 nyanpasu-core-manager = { path = ".", features = ["test-hooks"] }
 tempfile = "3"
+
+[features]
+default = []
+test-hooks = []

--- a/crates/nyanpasu-core-manager/src/control/executor.rs
+++ b/crates/nyanpasu-core-manager/src/control/executor.rs
@@ -61,7 +61,20 @@ impl Registry {
         }
     }
 
-    pub(super) fn admit(&self, id: OperationId, digest: &str) -> Result<Admission, CoreError> {
+    /// Registration and enqueue in one critical section.
+    ///
+    /// `enqueue` runs while the registry lock is held, so a concurrent submit
+    /// of the same id either does not see the entry at all or sees one that is
+    /// already queued. There is no window in which a caller can attach to a
+    /// registered operation that will never reach a terminal state — which is
+    /// why `enqueue` must be non-blocking (`try_send` / a reserved permit) and
+    /// must never call back into the registry.
+    pub(super) fn admit(
+        &self,
+        id: OperationId,
+        digest: &str,
+        enqueue: impl FnOnce() -> Result<(), mpsc::error::TrySendError<ExecutorWork>>,
+    ) -> Result<Admission, CoreError> {
         let mut inner = self.inner.lock();
         if let Some(existing) = inner.operations.get(&id) {
             if existing.digest == digest {
@@ -75,7 +88,9 @@ impl Registry {
             .with_operation(id));
         }
         // Evict the oldest *terminal* entries only. In-flight operations are
-        // never evicted; their count is already bounded by the work queue.
+        // never evicted: `CoreControl::spawn` clamps this capacity to the queue
+        // bound plus the one operation running outside the queue, so every live
+        // operation fits by construction.
         while inner.operations.len() >= self.capacity {
             let Some(position) = inner.order.iter().position(|id| {
                 inner
@@ -97,14 +112,24 @@ impl Registry {
             },
         );
         inner.order.push_back(id);
+        if let Err(error) = enqueue() {
+            inner.operations.remove(&id);
+            inner.order.pop_back();
+            let error = match error {
+                mpsc::error::TrySendError::Full(_) => CoreError::new(
+                    CoreErrorKind::QueueFull,
+                    "the operation queue is full",
+                    true,
+                ),
+                mpsc::error::TrySendError::Closed(_) => CoreError::new(
+                    CoreErrorKind::Internal,
+                    "the control executor is gone",
+                    false,
+                ),
+            };
+            return Err(error.with_operation(id));
+        }
         Ok(Admission::Registered(state_rx))
-    }
-
-    /// Rolls back a registration whose enqueue failed.
-    pub(super) fn remove(&self, id: OperationId) {
-        let mut inner = self.inner.lock();
-        inner.operations.remove(&id);
-        inner.order.retain(|entry| *entry != id);
     }
 
     pub(super) fn set(&self, id: OperationId, state: OperationState) {

--- a/crates/nyanpasu-core-manager/src/control/executor.rs
+++ b/crates/nyanpasu-core-manager/src/control/executor.rs
@@ -1,0 +1,268 @@
+//! The control executor: one task that owns every mutating operation from
+//! admission to a safe terminal state, isolated from caller cancellation
+//! (design §10). Callers hold [`super::OperationHandle`]s; dropping one never
+//! cancels the work it names.
+
+use std::collections::{HashMap, VecDeque};
+
+use camino::Utf8PathBuf;
+use tokio::sync::{mpsc, watch};
+
+use crate::{
+    error::{CoreErrorKind, Error},
+    manager::{ApplyOutcome, CoreManager},
+    spec::InstanceSpec,
+};
+
+use super::{
+    ConfigInput, CoreCommand, CoreError, OperationId, OperationOutput, OperationState,
+    ReconcileRequest, payload_digest,
+};
+
+pub(super) struct ExecutorWork {
+    pub(super) id: OperationId,
+    pub(super) command: CoreCommand,
+}
+
+/// Bounded most-recent-operations registry: the idempotency table and the
+/// query surface for lost-response recovery. Losing an entry never affects the
+/// runtime — a client that misses falls back to reading `CoreStatus`, and the
+/// revision CAS blocks double application (design §9.4).
+pub(super) struct Registry {
+    inner: parking_lot::Mutex<RegistryInner>,
+    capacity: usize,
+}
+
+struct RegistryInner {
+    operations: HashMap<OperationId, RegisteredOperation>,
+    order: VecDeque<OperationId>,
+}
+
+struct RegisteredOperation {
+    digest: String,
+    state_tx: watch::Sender<OperationState>,
+}
+
+pub(super) enum Admission {
+    /// New registration; the caller must enqueue the work.
+    Registered(watch::Receiver<OperationState>),
+    /// Same id + same digest: the original operation, wherever it is.
+    Existing(watch::Receiver<OperationState>),
+}
+
+impl Registry {
+    pub(super) fn new(capacity: usize) -> Self {
+        Self {
+            inner: parking_lot::Mutex::new(RegistryInner {
+                operations: HashMap::new(),
+                order: VecDeque::new(),
+            }),
+            capacity,
+        }
+    }
+
+    pub(super) fn admit(&self, id: OperationId, digest: &str) -> Result<Admission, CoreError> {
+        let mut inner = self.inner.lock();
+        if let Some(existing) = inner.operations.get(&id) {
+            if existing.digest == digest {
+                return Ok(Admission::Existing(existing.state_tx.subscribe()));
+            }
+            return Err(CoreError::new(
+                CoreErrorKind::OperationConflict,
+                format!("operation {id} was already submitted with a different payload"),
+                false,
+            )
+            .with_operation(id));
+        }
+        // Evict the oldest *terminal* entries only. In-flight operations are
+        // never evicted; their count is already bounded by the work queue.
+        while inner.operations.len() >= self.capacity {
+            let Some(position) = inner.order.iter().position(|id| {
+                inner
+                    .operations
+                    .get(id)
+                    .is_some_and(|operation| is_terminal(&operation.state_tx.borrow()))
+            }) else {
+                break;
+            };
+            let evicted = inner.order.remove(position).expect("position is in range");
+            inner.operations.remove(&evicted);
+        }
+        let (state_tx, state_rx) = watch::channel(OperationState::Queued);
+        inner.operations.insert(
+            id,
+            RegisteredOperation {
+                digest: digest.to_owned(),
+                state_tx,
+            },
+        );
+        inner.order.push_back(id);
+        Ok(Admission::Registered(state_rx))
+    }
+
+    /// Rolls back a registration whose enqueue failed.
+    pub(super) fn remove(&self, id: OperationId) {
+        let mut inner = self.inner.lock();
+        inner.operations.remove(&id);
+        inner.order.retain(|entry| *entry != id);
+    }
+
+    pub(super) fn set(&self, id: OperationId, state: OperationState) {
+        let inner = self.inner.lock();
+        if let Some(operation) = inner.operations.get(&id) {
+            let _ = operation.state_tx.send(state);
+        }
+    }
+
+    pub(super) fn get(&self, id: OperationId) -> Option<OperationState> {
+        let inner = self.inner.lock();
+        inner
+            .operations
+            .get(&id)
+            .map(|operation| operation.state_tx.borrow().clone())
+    }
+}
+
+fn is_terminal(state: &OperationState) -> bool {
+    matches!(
+        state,
+        OperationState::Succeeded(_) | OperationState::Failed(_)
+    )
+}
+
+pub(super) struct ExecutorContext {
+    pub(super) manager: CoreManager,
+    pub(super) registry: std::sync::Arc<Registry>,
+    pub(super) source_dir: Utf8PathBuf,
+    pub(super) working_dir: Utf8PathBuf,
+}
+
+pub(super) async fn run(mut rx: mpsc::Receiver<ExecutorWork>, context: ExecutorContext) {
+    while let Some(work) = rx.recv().await {
+        context.registry.set(work.id, OperationState::Running);
+        let is_shutdown = matches!(work.command, CoreCommand::Shutdown);
+        let state = match execute(&context, work.id, work.command).await {
+            Ok(output) => OperationState::Succeeded(output),
+            Err(error) => OperationState::Failed(error),
+        };
+        context.registry.set(work.id, state);
+        if is_shutdown {
+            break;
+        }
+    }
+    // Everything still queued was admitted before the shutdown drained the
+    // loop. A queued Shutdown *was* accomplished by the one that ran; anything
+    // else was not.
+    rx.close();
+    while let Ok(work) = rx.try_recv() {
+        let state = match work.command {
+            CoreCommand::Shutdown => OperationState::Succeeded(OperationOutput::ShutDown),
+            _ => OperationState::Failed(
+                CoreError::new(
+                    CoreErrorKind::ShuttingDown,
+                    "the control plane shut down before this queued operation ran",
+                    false,
+                )
+                .with_operation(work.id),
+            ),
+        };
+        context.registry.set(work.id, state);
+    }
+}
+
+async fn execute(
+    context: &ExecutorContext,
+    id: OperationId,
+    command: CoreCommand,
+) -> Result<OperationOutput, CoreError> {
+    let domain = |error: &Error| CoreError::from_domain(error, Some(id));
+    match command {
+        CoreCommand::Reconcile(request) => reconcile(context, id, *request)
+            .await
+            .map(OperationOutput::Reconciled),
+        CoreCommand::Stop => context
+            .manager
+            .stop()
+            .await
+            .map(|()| OperationOutput::Stopped)
+            .map_err(|error| domain(&error)),
+        CoreCommand::Recover => context
+            .manager
+            .recover_quarantine()
+            .await
+            .map(|()| OperationOutput::Recovered)
+            .map_err(|error| domain(&error)),
+        CoreCommand::Shutdown => context
+            .manager
+            .shutdown()
+            .await
+            .map(|()| OperationOutput::ShutDown)
+            .map_err(|error| domain(&error)),
+    }
+}
+
+async fn reconcile(
+    context: &ExecutorContext,
+    id: OperationId,
+    request: ReconcileRequest,
+) -> Result<ApplyOutcome, CoreError> {
+    let ReconcileRequest {
+        core,
+        config,
+        options,
+        expected_applied,
+    } = request;
+    let config_path = materialize(
+        &context.source_dir,
+        // One fixed name: mutating operations are serialized, and after the
+        // transaction the effective config lives in the runtime store, so the
+        // source never accumulates.
+        "reconcile-source.yaml",
+        config,
+        id,
+    )
+    .await?;
+    let spec = InstanceSpec {
+        core,
+        config_path,
+        working_dir: context.working_dir.clone(),
+        pid_file: None,
+        options,
+    };
+    context
+        .manager
+        .reconcile(spec, expected_applied)
+        .await
+        .map_err(|error| CoreError::from_domain(&error, Some(id)))
+}
+
+/// Writes portable config bytes to a host file for the path-based pipeline
+/// below the control plane. The digest is verified before anything else
+/// happens — a mismatch is a clean abort.
+pub(super) async fn materialize(
+    source_dir: &camino::Utf8Path,
+    file_name: &str,
+    config: ConfigInput,
+    id: OperationId,
+) -> Result<Utf8PathBuf, CoreError> {
+    let ConfigInput::Inline {
+        bytes,
+        expected_digest,
+    } = config;
+    if let Some(declared) = expected_digest {
+        let computed = payload_digest(&bytes);
+        if declared != computed {
+            return Err(CoreError::new(
+                CoreErrorKind::InvalidConfig,
+                format!("config digest mismatch: declared {declared}, computed {computed}"),
+                false,
+            )
+            .with_operation(id));
+        }
+    }
+    let io = |error: std::io::Error| CoreError::from_domain(&Error::Io(error), Some(id));
+    tokio::fs::create_dir_all(source_dir).await.map_err(io)?;
+    let path = source_dir.join(file_name);
+    tokio::fs::write(&path, &bytes).await.map_err(io)?;
+    Ok(path)
+}

--- a/crates/nyanpasu-core-manager/src/control/executor.rs
+++ b/crates/nyanpasu-core-manager/src/control/executor.rs
@@ -121,9 +121,17 @@ impl Registry {
             .get(&id)
             .map(|operation| operation.state_tx.borrow().clone())
     }
+
+    pub(super) fn subscribe(&self, id: OperationId) -> Option<watch::Receiver<OperationState>> {
+        let inner = self.inner.lock();
+        inner
+            .operations
+            .get(&id)
+            .map(|operation| operation.state_tx.subscribe())
+    }
 }
 
-fn is_terminal(state: &OperationState) -> bool {
+pub(super) fn is_terminal(state: &OperationState) -> bool {
     matches!(
         state,
         OperationState::Succeeded(_) | OperationState::Failed(_)

--- a/crates/nyanpasu-core-manager/src/control/executor.rs
+++ b/crates/nyanpasu-core-manager/src/control/executor.rs
@@ -42,18 +42,26 @@ pub(super) struct Registry {
 struct RegistryInner {
     operations: HashMap<OperationId, RegisteredOperation>,
     order: VecDeque<OperationId>,
+    next_sequence: u64,
 }
 
 struct RegisteredOperation {
     digest: String,
+    sequence: u64,
     state_tx: watch::Sender<OperationState>,
+}
+
+/// One admitted operation's place in the queue, and the channel to watch it on.
+pub(super) struct Admitted {
+    pub(super) sequence: u64,
+    pub(super) state_rx: watch::Receiver<OperationState>,
 }
 
 pub(super) enum Admission {
     /// New registration; the caller must enqueue the work.
-    Registered(watch::Receiver<OperationState>),
+    Registered(Admitted),
     /// Same id + same digest: the original operation, wherever it is.
-    Existing(watch::Receiver<OperationState>),
+    Existing(Admitted),
 }
 
 impl Registry {
@@ -62,6 +70,7 @@ impl Registry {
             inner: parking_lot::Mutex::new(RegistryInner {
                 operations: HashMap::new(),
                 order: VecDeque::new(),
+                next_sequence: 0,
             }),
             capacity,
         }
@@ -84,7 +93,10 @@ impl Registry {
         let mut inner = self.inner.lock();
         if let Some(existing) = inner.operations.get(&id) {
             if existing.digest == digest {
-                return Ok(Admission::Existing(existing.state_tx.subscribe()));
+                return Ok(Admission::Existing(Admitted {
+                    sequence: existing.sequence,
+                    state_rx: existing.state_tx.subscribe(),
+                }));
             }
             return Err(CoreError::new(
                 CoreErrorKind::OperationConflict,
@@ -110,10 +122,17 @@ impl Registry {
             inner.operations.remove(&evicted);
         }
         let (state_tx, state_rx) = watch::channel(OperationState::Queued);
+        // Assigned here, not by the caller: this is the same critical section
+        // the enqueue happens in, so the sequence is the order the executor
+        // will actually run these in. A caller that stamps its own would be
+        // stamping submit order, which two concurrent submits can invert.
+        let sequence = inner.next_sequence;
+        inner.next_sequence += 1;
         inner.operations.insert(
             id,
             RegisteredOperation {
                 digest: digest.to_owned(),
+                sequence,
                 state_tx,
             },
         );
@@ -135,7 +154,7 @@ impl Registry {
             };
             return Err(error.with_operation(id));
         }
-        Ok(Admission::Registered(state_rx))
+        Ok(Admission::Registered(Admitted { sequence, state_rx }))
     }
 
     pub(super) fn set(&self, id: OperationId, state: OperationState) {

--- a/crates/nyanpasu-core-manager/src/control/executor.rs
+++ b/crates/nyanpasu-core-manager/src/control/executor.rs
@@ -3,7 +3,13 @@
 //! (design §10). Callers hold [`super::OperationHandle`]s; dropping one never
 //! cancels the work it names.
 
-use std::collections::{HashMap, VecDeque};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use camino::Utf8PathBuf;
 use tokio::sync::{mpsc, watch};
@@ -135,7 +141,13 @@ impl Registry {
     pub(super) fn set(&self, id: OperationId, state: OperationState) {
         let inner = self.inner.lock();
         if let Some(operation) = inner.operations.get(&id) {
-            let _ = operation.state_tx.send(state);
+            // `send` is not `send_replace`: with no live receiver it returns
+            // the value back as an error and leaves the stored one untouched.
+            // Every caller that drops its handle -- the wire's fire-and-forget
+            // submit, for one -- would then leave this operation `Queued`
+            // forever, and the next long-poll would subscribe to a state that
+            // stopped advancing.
+            operation.state_tx.send_replace(state);
         }
     }
 
@@ -165,20 +177,78 @@ pub(super) fn is_terminal(state: &OperationState) -> bool {
 
 pub(super) struct ExecutorContext {
     pub(super) manager: CoreManager,
-    pub(super) registry: std::sync::Arc<Registry>,
+    pub(super) registry: Arc<Registry>,
     pub(super) source_dir: Utf8PathBuf,
     pub(super) working_dir: Utf8PathBuf,
+    /// Shared with [`super::CoreControl`]: the executor is the only writer
+    /// after `shutdown` latches it, and the latch is what makes queued work
+    /// refuse rather than run behind a shutdown.
+    pub(super) closing: Arc<AtomicBool>,
 }
 
-pub(super) async fn run(mut rx: mpsc::Receiver<ExecutorWork>, context: ExecutorContext) {
+pub(super) async fn run(
+    mut rx: mpsc::Receiver<ExecutorWork>,
+    context: Arc<ExecutorContext>,
+) -> super::ExecutorExit {
     while let Some(work) = rx.recv().await {
-        context.registry.set(work.id, OperationState::Running);
-        let is_shutdown = matches!(work.command, CoreCommand::Shutdown);
-        let state = match execute(&context, work.id, work.command).await {
-            Ok(output) => OperationState::Succeeded(output),
-            Err(error) => OperationState::Failed(error),
+        let ExecutorWork { id, command } = work;
+        let is_shutdown = matches!(command, CoreCommand::Shutdown);
+        // Admission latched closing before this operation was dequeued: it was
+        // queued for a control plane that no longer accepts work, so it is
+        // refused here rather than executed behind the shutdown.
+        if !is_shutdown && context.closing.load(Ordering::Acquire) {
+            context.registry.set(
+                id,
+                OperationState::Failed(
+                    CoreError::new(
+                        CoreErrorKind::ShuttingDown,
+                        "the control plane is shutting down",
+                        false,
+                    )
+                    .with_operation(id),
+                ),
+            );
+            continue;
+        }
+        context.registry.set(id, OperationState::Running);
+        // One task per operation, so a panic inside a transaction becomes a
+        // `JoinError` here instead of unwinding the executor and leaving every
+        // in-flight and queued operation without a terminal state. The executor
+        // still awaits it, so operations stay serialized.
+        let operation_context = context.clone();
+        let outcome =
+            tokio::spawn(async move { execute(&operation_context, id, command).await }).await;
+        let state = match outcome {
+            Ok(Ok(output)) => OperationState::Succeeded(output),
+            Ok(Err(error)) => OperationState::Failed(error),
+            Err(join) => {
+                // The guard over `Ctrl` was released while unwinding, so the
+                // orchestrator's state may be half-updated. `Died` is fatal by
+                // design: the executor terminalizes what it can and stops.
+                context.registry.set(
+                    id,
+                    OperationState::Failed(
+                        CoreError::new(
+                            CoreErrorKind::Internal,
+                            format!("the control operation panicked: {join}"),
+                            false,
+                        )
+                        .with_operation(id),
+                    ),
+                );
+                context.closing.store(true, Ordering::Release);
+                // A queued Shutdown did not happen either: nothing ran it.
+                drain(&mut rx, &context, |work| {
+                    OperationState::Failed(
+                        CoreError::new(CoreErrorKind::Internal, "the control executor died", false)
+                            .with_operation(work.id),
+                    )
+                })
+                .await;
+                return super::ExecutorExit::Died;
+            }
         };
-        context.registry.set(work.id, state);
+        context.registry.set(id, state);
         if is_shutdown {
             break;
         }
@@ -186,20 +256,37 @@ pub(super) async fn run(mut rx: mpsc::Receiver<ExecutorWork>, context: ExecutorC
     // Everything still queued was admitted before the shutdown drained the
     // loop. A queued Shutdown *was* accomplished by the one that ran; anything
     // else was not.
+    drain(&mut rx, &context, |work| match work.command {
+        CoreCommand::Shutdown => OperationState::Succeeded(OperationOutput::ShutDown),
+        _ => OperationState::Failed(
+            CoreError::new(
+                CoreErrorKind::ShuttingDown,
+                "the control plane shut down before this queued operation ran",
+                false,
+            )
+            .with_operation(work.id),
+        ),
+    })
+    .await;
+    super::ExecutorExit::Clean
+}
+
+/// Closes the queue and gives every operation still in it a terminal state.
+///
+/// `recv` and not `try_recv`: closing the receiver stops new senders but leaves
+/// a permit already handed out by [`mpsc::Sender::reserve`] valid, and
+/// `try_recv` reports the buffer empty while such a permit is still in flight.
+/// Awaiting instead waits for every outstanding permit to be used or dropped,
+/// which is what makes "every admitted operation reaches a terminal state" true
+/// rather than merely usually true.
+async fn drain(
+    rx: &mut mpsc::Receiver<ExecutorWork>,
+    context: &ExecutorContext,
+    terminal: impl Fn(&ExecutorWork) -> OperationState,
+) {
     rx.close();
-    while let Ok(work) = rx.try_recv() {
-        let state = match work.command {
-            CoreCommand::Shutdown => OperationState::Succeeded(OperationOutput::ShutDown),
-            _ => OperationState::Failed(
-                CoreError::new(
-                    CoreErrorKind::ShuttingDown,
-                    "the control plane shut down before this queued operation ran",
-                    false,
-                )
-                .with_operation(work.id),
-            ),
-        };
-        context.registry.set(work.id, state);
+    while let Some(work) = rx.recv().await {
+        context.registry.set(work.id, terminal(&work));
     }
 }
 

--- a/crates/nyanpasu-core-manager/src/control/mod.rs
+++ b/crates/nyanpasu-core-manager/src/control/mod.rs
@@ -267,7 +267,7 @@ impl CoreError {
         Self {
             kind,
             message: error.to_string(),
-            retryable: kind.is_some_and(default_retryable),
+            retryable: kind.is_some_and(|kind| kind.default_retryable()),
             operation_id,
         }
     }
@@ -288,16 +288,6 @@ impl std::fmt::Display for CoreError {
 }
 
 impl std::error::Error for CoreError {}
-
-/// Kinds that are retryable regardless of the situation that produced them.
-/// Everything else defaults to non-retryable and the producer overrides where
-/// it knows better.
-fn default_retryable(kind: CoreErrorKind) -> bool {
-    matches!(
-        kind,
-        CoreErrorKind::QueueFull | CoreErrorKind::BackendUnavailable
-    )
-}
 
 /// Registry-visible lifecycle of one operation (design §9.4).
 #[derive(Debug, Clone)]
@@ -766,9 +756,9 @@ mod tests {
     #[test]
     fn admission_kinds_default_to_retryable() {
         assert!(CoreError::new(CoreErrorKind::QueueFull, "full", true).retryable);
-        assert!(default_retryable(CoreErrorKind::QueueFull));
-        assert!(default_retryable(CoreErrorKind::BackendUnavailable));
-        assert!(!default_retryable(CoreErrorKind::OperationConflict));
-        assert!(!default_retryable(CoreErrorKind::ShuttingDown));
+        assert!(CoreErrorKind::QueueFull.default_retryable());
+        assert!(CoreErrorKind::BackendUnavailable.default_retryable());
+        assert!(!CoreErrorKind::OperationConflict.default_retryable());
+        assert!(!CoreErrorKind::ShuttingDown.default_retryable());
     }
 }

--- a/crates/nyanpasu-core-manager/src/control/mod.rs
+++ b/crates/nyanpasu-core-manager/src/control/mod.rs
@@ -453,6 +453,27 @@ impl CoreControl {
         self.registry.get(id)
     }
 
+    /// Long-poll surface for RPC hosts: the operation's state after `timeout`,
+    /// or its terminal state the moment it reaches one — whichever comes
+    /// first. `None` for an unknown or evicted id.
+    pub async fn wait_operation(
+        &self,
+        id: OperationId,
+        timeout: std::time::Duration,
+    ) -> Option<OperationState> {
+        let mut state_rx = self.registry.subscribe(id)?;
+        let _ = tokio::time::timeout(timeout, async {
+            while !executor::is_terminal(&state_rx.borrow_and_update()) {
+                if state_rx.changed().await.is_err() {
+                    break;
+                }
+            }
+        })
+        .await;
+        let state = state_rx.borrow().clone();
+        Some(state)
+    }
+
     /// Advisory, read-only config validation (amendment A2): bounded
     /// concurrency, never queued, and never a precondition for any change.
     pub async fn check(&self, request: CheckRequest) -> Result<(), CoreError> {

--- a/crates/nyanpasu-core-manager/src/control/mod.rs
+++ b/crates/nyanpasu-core-manager/src/control/mod.rs
@@ -425,25 +425,26 @@ impl CoreControl {
             id,
             command: envelope.command,
         };
-        let (state_rx, newly_admitted) = match self
+        let (admitted, newly_admitted) = match self
             .registry
             .admit(id, &digest, || self.work_tx.try_send(work))?
         {
-            Admission::Existing(state_rx) => (state_rx, false),
-            Admission::Registered(state_rx) => {
+            Admission::Existing(admitted) => (admitted, false),
+            Admission::Registered(admitted) => {
                 // Only after the work is queued: a latch set beside a rejected
                 // enqueue would refuse every later submit for a shutdown that
                 // never happened.
                 if is_shutdown {
                     self.closing.store(true, Ordering::Release);
                 }
-                (state_rx, true)
+                (admitted, true)
             }
         };
         Ok(OperationHandle {
             id,
-            state_rx,
+            state_rx: admitted.state_rx,
             newly_admitted,
+            sequence: admitted.sequence,
         })
     }
 
@@ -477,16 +478,17 @@ impl CoreControl {
         let id = OperationId::generate();
         let command = CoreCommand::Shutdown;
         let digest = command.payload_digest();
-        let state_rx = match self.registry.admit(id, &digest, move || {
+        let admitted = match self.registry.admit(id, &digest, move || {
             permit.send(ExecutorWork { id, command });
             Ok(())
         })? {
-            Admission::Registered(state_rx) | Admission::Existing(state_rx) => state_rx,
+            Admission::Registered(admitted) | Admission::Existing(admitted) => admitted,
         };
         OperationHandle {
             id,
-            state_rx,
+            state_rx: admitted.state_rx,
             newly_admitted: true,
+            sequence: admitted.sequence,
         }
         .wait()
         .await
@@ -605,6 +607,7 @@ pub struct OperationHandle {
     id: OperationId,
     state_rx: watch::Receiver<OperationState>,
     newly_admitted: bool,
+    sequence: u64,
 }
 
 impl OperationHandle {
@@ -617,6 +620,18 @@ impl OperationHandle {
     /// that start per-operation work on admission use it to start it once.
     pub fn newly_admitted(&self) -> bool {
         self.newly_admitted
+    }
+
+    /// Where this operation sits in the executor's run order, counted from the
+    /// control plane's start.
+    ///
+    /// It exists for hosts that mirror an operation's effect somewhere else and
+    /// have to apply those mirrors in the order the transactions committed:
+    /// operations run serially, but whatever watches them does not, so two
+    /// completions can be observed out of order and a stale one would overwrite
+    /// the current value.
+    pub fn sequence(&self) -> u64 {
+        self.sequence
     }
 
     pub fn state(&self) -> OperationState {

--- a/crates/nyanpasu-core-manager/src/control/mod.rs
+++ b/crates/nyanpasu-core-manager/src/control/mod.rs
@@ -176,8 +176,14 @@ pub enum CoreCommand {
 impl CoreCommand {
     /// The identity digest the idempotency registry compares: two envelopes
     /// with the same [`OperationId`] must describe the same work. Config
-    /// bytes, the desired core, and the CAS token are identity; tuning fields
-    /// ([`InstanceOptions`]) deliberately are not.
+    /// bytes, the desired core, the CAS token, and the declared config digest
+    /// are identity; tuning fields ([`InstanceOptions`]) deliberately are not.
+    ///
+    /// A corrected `expected_digest` is therefore a *different* envelope: the
+    /// two describe different claims about the same bytes, and re-submitting
+    /// under the original id answers `OperationConflict` rather than replaying
+    /// the first attempt's `InvalidConfig`. Callers that fix a digest must use
+    /// a fresh id.
     pub fn payload_digest(&self) -> String {
         use std::fmt::Write;
         match self {
@@ -197,8 +203,14 @@ impl CoreCommand {
                 }
                 identity.push('\0');
                 let mut payload = identity.into_bytes();
-                let ConfigInput::Inline { bytes, .. } = &request.config;
+                let ConfigInput::Inline {
+                    bytes,
+                    expected_digest,
+                } = &request.config;
                 payload.extend_from_slice(bytes);
+                payload.extend_from_slice(b"\0digest:");
+                payload
+                    .extend_from_slice(expected_digest.as_deref().unwrap_or_default().as_bytes());
                 payload_digest(&payload)
             }
             Self::Stop => payload_digest(b"stop"),
@@ -361,7 +373,10 @@ impl CoreControl {
             registry_capacity,
             check_concurrency,
         } = options;
-        let registry = Arc::new(Registry::new(registry_capacity));
+        let registry = Arc::new(Registry::new(live_registry_capacity(
+            registry_capacity,
+            queue_capacity,
+        )));
         let (work_tx, work_rx) = mpsc::channel(queue_capacity);
         let (done_tx, done_rx) = watch::channel(false);
         let context = ExecutorContext {
@@ -400,42 +415,31 @@ impl CoreControl {
             .with_operation(id));
         }
         let digest = envelope.command.payload_digest();
-        let state_rx = match self.registry.admit(id, &digest)? {
-            Admission::Existing(state_rx) => state_rx,
+        let is_shutdown = matches!(envelope.command, CoreCommand::Shutdown);
+        let work = ExecutorWork {
+            id,
+            command: envelope.command,
+        };
+        let (state_rx, newly_admitted) = match self
+            .registry
+            .admit(id, &digest, || self.work_tx.try_send(work))?
+        {
+            Admission::Existing(state_rx) => (state_rx, false),
             Admission::Registered(state_rx) => {
-                let is_shutdown = matches!(envelope.command, CoreCommand::Shutdown);
-                match self.work_tx.try_send(ExecutorWork {
-                    id,
-                    command: envelope.command,
-                }) {
-                    Ok(()) => {
-                        if is_shutdown {
-                            self.closing.store(true, Ordering::Release);
-                        }
-                        state_rx
-                    }
-                    Err(mpsc::error::TrySendError::Full(_)) => {
-                        self.registry.remove(id);
-                        return Err(CoreError::new(
-                            CoreErrorKind::QueueFull,
-                            "the operation queue is full",
-                            true,
-                        )
-                        .with_operation(id));
-                    }
-                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                        self.registry.remove(id);
-                        return Err(CoreError::new(
-                            CoreErrorKind::Internal,
-                            "the control executor is gone",
-                            false,
-                        )
-                        .with_operation(id));
-                    }
+                // Only after the work is queued: a latch set beside a rejected
+                // enqueue would refuse every later submit for a shutdown that
+                // never happened.
+                if is_shutdown {
+                    self.closing.store(true, Ordering::Release);
                 }
+                (state_rx, true)
             }
         };
-        Ok(OperationHandle { id, state_rx })
+        Ok(OperationHandle {
+            id,
+            state_rx,
+            newly_admitted,
+        })
     }
 
     /// Zero-mailbox snapshot read.
@@ -490,8 +494,11 @@ impl CoreControl {
             )
         })?;
         let ConfigInput::Inline { bytes, .. } = &request.config;
-        let file_name = format!("check-source-{}.yaml", payload_digest(bytes));
         let id = OperationId::generate();
+        // The id, not just the digest: two concurrent checks of the same bytes
+        // must not share a file, or the first one to finish deletes the source
+        // the other is still reading.
+        let file_name = format!("check-source-{}-{id}.yaml", payload_digest(bytes));
         let config_path =
             executor::materialize(&self.source_dir, &file_name, request.config, id).await?;
         let spec = InstanceSpec {
@@ -502,8 +509,7 @@ impl CoreControl {
             options: InstanceOptions::default(),
         };
         let result = self.manager.check_config(&spec).await;
-        // Best-effort cleanup; a concurrent same-digest check rewrites the
-        // same bytes, so a failed removal is harmless.
+        // Best-effort cleanup of this call's own source file.
         let _ = tokio::fs::remove_file(&config_path).await;
         result.map_err(|error| CoreError::from_domain(&error, None))
     }
@@ -524,6 +530,15 @@ impl CoreControl {
     }
 }
 
+/// The registry bound the executor actually runs with: at most
+/// `queue_capacity` operations wait while one runs outside the queue, so a
+/// smaller configured bound is raised rather than honored. A misconfigured
+/// host should not turn into a run-time `QueueFull`; the invariant "every live
+/// operation has a registry entry" holds by construction instead.
+fn live_registry_capacity(registry_capacity: usize, queue_capacity: usize) -> usize {
+    registry_capacity.max(queue_capacity.saturating_add(1))
+}
+
 /// A submitted operation. `wait` consumes the handle and resolves with the
 /// terminal result; `state` polls without consuming. Dropping the handle
 /// leaves the operation running to its safe terminal state.
@@ -531,11 +546,19 @@ impl CoreControl {
 pub struct OperationHandle {
     id: OperationId,
     state_rx: watch::Receiver<OperationState>,
+    newly_admitted: bool,
 }
 
 impl OperationHandle {
     pub fn id(&self) -> OperationId {
         self.id
+    }
+
+    /// Whether this handle registered the operation, as opposed to attaching
+    /// to one that was already submitted under the same id and payload. Hosts
+    /// that start per-operation work on admission use it to start it once.
+    pub fn newly_admitted(&self) -> bool {
+        self.newly_admitted
     }
 
     pub fn state(&self) -> OperationState {
@@ -634,6 +657,37 @@ mod tests {
                 counter: 7,
             })
         );
+    }
+
+    #[test]
+    fn the_registry_bound_is_clamped_to_hold_every_live_operation() {
+        // A host that configures fewer registry slots than the queue can hold
+        // gets the queue bound plus the running operation, not its own number.
+        assert_eq!(live_registry_capacity(1, 2), 3);
+        assert_eq!(live_registry_capacity(64, 16), 64);
+    }
+
+    #[test]
+    fn a_corrected_declared_digest_is_a_different_payload() {
+        let request = |expected_digest: Option<&str>| ReconcileRequest {
+            core: CoreSpec {
+                kind: crate::kind::CoreKind::Mihomo,
+                binary_path: Utf8PathBuf::from("core"),
+                version: None,
+                features: Vec::new(),
+            },
+            config: ConfigInput::Inline {
+                bytes: b"mixed-port: 7890\n".to_vec(),
+                expected_digest: expected_digest.map(str::to_owned),
+            },
+            options: InstanceOptions::default(),
+            expected_applied: None,
+        };
+        let wrong = CoreCommand::Reconcile(Box::new(request(Some("0000000000000000"))));
+        let right = CoreCommand::Reconcile(Box::new(request(Some("1111111111111111"))));
+        let absent = CoreCommand::Reconcile(Box::new(request(None)));
+        assert_ne!(wrong.payload_digest(), right.payload_digest());
+        assert_ne!(wrong.payload_digest(), absent.payload_digest());
     }
 
     #[test]

--- a/crates/nyanpasu-core-manager/src/control/mod.rs
+++ b/crates/nyanpasu-core-manager/src/control/mod.rs
@@ -1,0 +1,312 @@
+//! Portable control-plane command surface: operation identity, commands, and
+//! operation results.
+//!
+//! Design: `docs/design/2026-08-08-core-manager-control-plane-runtime-backend-design.md`
+//! (§9, §16, §25, with the 2026-08-12 amendments). Two deliberate deviations
+//! from that draft, decided at implementation time:
+//!
+//! - Check is not a [`CoreCommand`] variant. Amendment A2 degrades check to an
+//!   advisory, read-only call that never enters the mutating queue, so it is a
+//!   separate control method rather than an impossible registry state.
+//! - [`CoreError::kind`] is `Option`. The R0 protocol rule is that naming a
+//!   kind is a statement of fact about the failure and a guessed kind is worse
+//!   than an absent one; unclassified failures stay unclassified.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use crate::{
+    error::CoreErrorKind,
+    manager::ApplyOutcome,
+    spec::{CoreSpec, InstanceOptions},
+    state::RevisionId,
+};
+
+/// Correlation, idempotency, and event-tracing identity of one control
+/// request. Not a lease, a session, or a lock: it never grants ownership and
+/// never blocks another operation (design §9.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct OperationId([u8; 16]);
+
+impl OperationId {
+    pub const fn from_bytes(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    pub const fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+
+    /// Convenience generator for local callers that do not carry their own id.
+    ///
+    /// Uniqueness comes from (unix nanos, pid, process-local counter). This is
+    /// an identity for the bounded operation registry, not a cryptographic
+    /// token; remote callers supply their own ids.
+    pub fn generate() -> Self {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        let mut bytes = [0u8; 16];
+        bytes[..8].copy_from_slice(&nanos.to_be_bytes());
+        bytes[8..12].copy_from_slice(&std::process::id().to_be_bytes());
+        bytes[12..16].copy_from_slice(&COUNTER.fetch_add(1, Ordering::Relaxed).to_be_bytes());
+        Self(bytes)
+    }
+}
+
+impl std::fmt::Display for OperationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseOperationIdError;
+
+impl std::fmt::Display for ParseOperationIdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("an operation id is exactly 32 lowercase hex characters")
+    }
+}
+
+impl std::error::Error for ParseOperationIdError {}
+
+impl std::str::FromStr for OperationId {
+    type Err = ParseOperationIdError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.len() != 32 || !value.is_ascii() {
+            return Err(ParseOperationIdError);
+        }
+        let mut bytes = [0u8; 16];
+        for (index, chunk) in value.as_bytes().chunks_exact(2).enumerate() {
+            let chunk = std::str::from_utf8(chunk).map_err(|_| ParseOperationIdError)?;
+            bytes[index] = u8::from_str_radix(chunk, 16).map_err(|_| ParseOperationIdError)?;
+        }
+        Ok(Self(bytes))
+    }
+}
+
+/// Change-identity digest over a raw payload: stable FNV-1a, hex-encoded. The
+/// idempotency registry compares digests, never full payloads; this is not a
+/// cryptographic integrity primitive.
+pub fn payload_digest(bytes: &[u8]) -> String {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:016x}")
+}
+
+/// Portable configuration payload. The control plane never reads caller
+/// filesystem paths; a host that has a path performs read → digest → `Inline`
+/// at its own boundary (design §16.2). A `Resource` variant is deferred until
+/// a config store consumer exists.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigInput {
+    Inline {
+        bytes: Vec<u8>,
+        /// [`payload_digest`] of `bytes` as the caller computed it, verified
+        /// on receipt when present.
+        expected_digest: Option<String>,
+    },
+}
+
+impl ConfigInput {
+    pub fn inline(bytes: Vec<u8>) -> Self {
+        Self::Inline {
+            bytes,
+            expected_digest: None,
+        }
+    }
+}
+
+/// The single mutating convergence command (amendment A2): make the runtime
+/// match this desired core + config. Start, restart, apply, and switch are
+/// classifications the orchestrator derives internally, not caller choices.
+#[derive(Debug, Clone)]
+pub struct ReconcileRequest {
+    pub core: CoreSpec,
+    pub config: ConfigInput,
+    pub options: InstanceOptions,
+    /// Compare-and-swap token: the revision the caller believes is applied.
+    /// `None` skips the comparison (unconditional reconcile).
+    pub expected_applied: Option<RevisionId>,
+}
+
+/// Advisory, read-only validation (amendment A2): concurrency-limited, never
+/// queued, and never a precondition for any change.
+#[derive(Debug, Clone)]
+pub struct CheckRequest {
+    pub core: CoreSpec,
+    pub config: ConfigInput,
+}
+
+/// A mutating control command. Serialized by the control executor; every
+/// variant runs as one transaction to a safe terminal state.
+#[derive(Debug, Clone)]
+pub enum CoreCommand {
+    Reconcile(Box<ReconcileRequest>),
+    Stop,
+    Recover,
+    Shutdown,
+}
+
+#[derive(Debug, Clone)]
+pub struct CoreCommandEnvelope {
+    pub operation_id: OperationId,
+    pub command: CoreCommand,
+}
+
+/// The successful terminal payload of one operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OperationOutput {
+    Reconciled(ApplyOutcome),
+    Stopped,
+    Recovered,
+    ShutDown,
+}
+
+/// Portable, cloneable error surface of the control plane (design §25). The
+/// domain [`Error`](crate::Error) is converted at the executor boundary so the
+/// registry can replay the same terminal result to idempotent re-submits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoreError {
+    /// See the module doc: `None` means unclassified, never "no error".
+    pub kind: Option<CoreErrorKind>,
+    /// Human-readable and unstable; never a branch condition.
+    pub message: String,
+    /// Whether resubmitting the same envelope can plausibly succeed. Set by
+    /// the producer: the same kind can be retryable in one situation and not
+    /// another (an `OperationConflict` from a handoff in progress is; one from
+    /// an id reused with a different payload is not).
+    pub retryable: bool,
+    pub operation_id: Option<OperationId>,
+}
+
+impl CoreError {
+    pub fn new(kind: CoreErrorKind, message: impl Into<String>, retryable: bool) -> Self {
+        Self {
+            kind: Some(kind),
+            message: message.into(),
+            retryable,
+            operation_id: None,
+        }
+    }
+
+    pub fn from_domain(error: &crate::Error, operation_id: Option<OperationId>) -> Self {
+        let kind = error.kind();
+        Self {
+            kind,
+            message: error.to_string(),
+            retryable: kind.is_some_and(default_retryable),
+            operation_id,
+        }
+    }
+
+    pub fn with_operation(mut self, operation_id: OperationId) -> Self {
+        self.operation_id = Some(operation_id);
+        self
+    }
+}
+
+impl std::fmt::Display for CoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            Some(kind) => write!(f, "{kind}: {}", self.message),
+            None => f.write_str(&self.message),
+        }
+    }
+}
+
+impl std::error::Error for CoreError {}
+
+/// Kinds that are retryable regardless of the situation that produced them.
+/// Everything else defaults to non-retryable and the producer overrides where
+/// it knows better.
+fn default_retryable(kind: CoreErrorKind) -> bool {
+    matches!(
+        kind,
+        CoreErrorKind::QueueFull | CoreErrorKind::BackendUnavailable
+    )
+}
+
+/// Registry-visible lifecycle of one operation (design §9.4).
+#[derive(Debug, Clone)]
+pub enum OperationState {
+    Queued,
+    Running,
+    Succeeded(OperationOutput),
+    Failed(CoreError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn operation_ids_roundtrip_through_hex() {
+        let id = OperationId::from_bytes([
+            0x00, 0x01, 0x0a, 0x10, 0x7f, 0x80, 0xff, 0x42, 0x00, 0x01, 0x0a, 0x10, 0x7f, 0x80,
+            0xff, 0x42,
+        ]);
+        let text = id.to_string();
+        assert_eq!(text.len(), 32);
+        assert_eq!(OperationId::from_str(&text).unwrap(), id);
+    }
+
+    #[test]
+    fn malformed_operation_ids_are_rejected() {
+        for bad in ["", "abc", &"a".repeat(31), &"g".repeat(32), &"a".repeat(33)] {
+            assert_eq!(OperationId::from_str(bad), Err(ParseOperationIdError));
+        }
+    }
+
+    #[test]
+    fn generated_operation_ids_differ() {
+        assert_ne!(OperationId::generate(), OperationId::generate());
+    }
+
+    #[test]
+    fn the_payload_digest_is_stable_and_content_sensitive() {
+        assert_eq!(payload_digest(b"abc"), payload_digest(b"abc"));
+        assert_ne!(payload_digest(b"abc"), payload_digest(b"abd"));
+        // Pinned so a silent algorithm change cannot slip past the idempotency
+        // registry's stored digests.
+        assert_eq!(payload_digest(b""), "cbf29ce484222325");
+    }
+
+    #[test]
+    fn domain_errors_convert_with_their_kind_and_default_retryability() {
+        let error = CoreError::from_domain(&crate::Error::AlreadyRunning, None);
+        assert_eq!(error.kind, Some(CoreErrorKind::AlreadyRunning));
+        assert!(!error.retryable);
+
+        let unclassified = CoreError::from_domain(
+            &crate::Error::Io(std::io::Error::other("boom")),
+            Some(OperationId::from_bytes([7; 16])),
+        );
+        assert_eq!(unclassified.kind, None);
+        assert!(!unclassified.retryable);
+        assert_eq!(
+            unclassified.operation_id,
+            Some(OperationId::from_bytes([7; 16]))
+        );
+    }
+
+    #[test]
+    fn admission_kinds_default_to_retryable() {
+        assert!(CoreError::new(CoreErrorKind::QueueFull, "full", true).retryable);
+        assert!(default_retryable(CoreErrorKind::QueueFull));
+        assert!(default_retryable(CoreErrorKind::BackendUnavailable));
+        assert!(!default_retryable(CoreErrorKind::OperationConflict));
+        assert!(!default_retryable(CoreErrorKind::ShuttingDown));
+    }
+}

--- a/crates/nyanpasu-core-manager/src/control/mod.rs
+++ b/crates/nyanpasu-core-manager/src/control/mod.rs
@@ -447,6 +447,59 @@ impl CoreControl {
         })
     }
 
+    /// Shuts the control plane down through its own executor, and waits.
+    ///
+    /// The latch goes down *before* the command is queued — the reverse of
+    /// `submit(Shutdown)`, and the whole point: work already waiting in the
+    /// queue is refused by the executor instead of running behind the
+    /// shutdown. A host that stops the core by any other route can watch its
+    /// own shutdown put a core back up.
+    ///
+    /// Queue pressure waits rather than answering `QueueFull`: everything in
+    /// front is about to be refused, so a slot frees promptly.
+    pub async fn shutdown(&self) -> Result<(), CoreError> {
+        self.closing.store(true, Ordering::Release);
+        let permit = match self.work_tx.reserve().await {
+            Ok(permit) => permit,
+            // The executor already exited; there is nothing left to run a
+            // shutdown, so report how it went instead of inventing one.
+            Err(_) => {
+                return match self.until_closed().await {
+                    ExecutorExit::Clean => Ok(()),
+                    ExecutorExit::Died => Err(CoreError::new(
+                        CoreErrorKind::Internal,
+                        "the control executor died",
+                        false,
+                    )),
+                };
+            }
+        };
+        let id = OperationId::generate();
+        let command = CoreCommand::Shutdown;
+        let digest = command.payload_digest();
+        let state_rx = match self.registry.admit(id, &digest, move || {
+            permit.send(ExecutorWork { id, command });
+            Ok(())
+        })? {
+            Admission::Registered(state_rx) | Admission::Existing(state_rx) => state_rx,
+        };
+        OperationHandle {
+            id,
+            state_rx,
+            newly_admitted: true,
+        }
+        .wait()
+        .await
+        .map(drop)
+    }
+
+    /// Whether the executor is gone: its receiver was dropped, so nothing can
+    /// own a transaction any more. A host uses this to tell a failed shutdown
+    /// apart from one that had no executor to run it.
+    pub fn executor_is_closed(&self) -> bool {
+        self.work_tx.is_closed()
+    }
+
     /// Zero-mailbox snapshot read.
     pub fn status(&self) -> CoreStatus {
         self.manager.status()

--- a/crates/nyanpasu-core-manager/src/control/mod.rs
+++ b/crates/nyanpasu-core-manager/src/control/mod.rs
@@ -21,6 +21,7 @@ use std::sync::{
 
 use camino::Utf8PathBuf;
 use tokio::sync::{Semaphore, broadcast, mpsc, watch};
+use zerocopy::{ByteEq, ByteHash, FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use crate::{
     error::CoreErrorKind,
@@ -34,19 +35,15 @@ use executor::{Admission, ExecutorContext, ExecutorWork, Registry};
 
 /// Correlation, idempotency, and event-tracing identity of one control
 /// request. Not a lease, a session, or a lock: it never grants ownership and
-/// never blocks another operation (design §9.2).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct OperationId([u8; 16]);
+/// never blocks another operation
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, KnownLayout, ByteEq, ByteHash, Immutable)]
+pub struct OperationId {
+    pub nanos: u64,
+    pub pid: u32,
+    pub counter: u32,
+}
 
 impl OperationId {
-    pub const fn from_bytes(bytes: [u8; 16]) -> Self {
-        Self(bytes)
-    }
-
-    pub const fn as_bytes(&self) -> &[u8; 16] {
-        &self.0
-    }
-
     /// Convenience generator for local callers that do not carry their own id.
     ///
     /// Uniqueness comes from (unix nanos, pid, process-local counter). This is
@@ -58,20 +55,21 @@ impl OperationId {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_nanos() as u64;
-        let mut bytes = [0u8; 16];
-        bytes[..8].copy_from_slice(&nanos.to_be_bytes());
-        bytes[8..12].copy_from_slice(&std::process::id().to_be_bytes());
-        bytes[12..16].copy_from_slice(&COUNTER.fetch_add(1, Ordering::Relaxed).to_be_bytes());
-        Self(bytes)
+        Self {
+            nanos,
+            pid: std::process::id(),
+            counter: COUNTER.fetch_add(1, Ordering::Relaxed),
+        }
     }
 }
 
 impl std::fmt::Display for OperationId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for byte in self.0 {
-            write!(f, "{byte:02x}")?;
-        }
-        Ok(())
+        write!(
+            f,
+            "{:016x}-{:08x}-{:08x}",
+            self.nanos, self.pid, self.counter
+        )
     }
 }
 
@@ -80,7 +78,7 @@ pub struct ParseOperationIdError;
 
 impl std::fmt::Display for ParseOperationIdError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("an operation id is exactly 32 lowercase hex characters")
+        f.write_str("an operation id must be lowercase hexadecimal in 16-8-8 format")
     }
 }
 
@@ -90,15 +88,22 @@ impl std::str::FromStr for OperationId {
     type Err = ParseOperationIdError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        if value.len() != 32 || !value.is_ascii() {
+        let (nanos, rest) = value.split_once('-').ok_or(ParseOperationIdError)?;
+        let (pid, counter) = rest.split_once('-').ok_or(ParseOperationIdError)?;
+        if nanos.len() != 16
+            || pid.len() != 8
+            || counter.len() != 8
+            || !value
+                .bytes()
+                .all(|byte| byte == b'-' || byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
             return Err(ParseOperationIdError);
         }
-        let mut bytes = [0u8; 16];
-        for (index, chunk) in value.as_bytes().as_chunks::<2>().0.iter().enumerate() {
-            let chunk = std::str::from_utf8(chunk).map_err(|_| ParseOperationIdError)?;
-            bytes[index] = u8::from_str_radix(chunk, 16).map_err(|_| ParseOperationIdError)?;
-        }
-        Ok(Self(bytes))
+        Ok(Self {
+            nanos: u64::from_str_radix(nanos, 16).map_err(|_| ParseOperationIdError)?,
+            pid: u32::from_str_radix(pid, 16).map_err(|_| ParseOperationIdError)?,
+            counter: u32::from_str_radix(counter, 16).map_err(|_| ParseOperationIdError)?,
+        })
     }
 }
 
@@ -564,18 +569,29 @@ mod tests {
 
     #[test]
     fn operation_ids_roundtrip_through_hex() {
-        let id = OperationId::from_bytes([
-            0x00, 0x01, 0x0a, 0x10, 0x7f, 0x80, 0xff, 0x42, 0x00, 0x01, 0x0a, 0x10, 0x7f, 0x80,
-            0xff, 0x42,
-        ]);
+        let id = OperationId {
+            nanos: 0x0001_0a10_7f80_ff42,
+            pid: 0x0001_0a10,
+            counter: 0x7f80_ff42,
+        };
         let text = id.to_string();
-        assert_eq!(text.len(), 32);
+        assert_eq!(text, "00010a107f80ff42-00010a10-7f80ff42");
         assert_eq!(OperationId::from_str(&text).unwrap(), id);
     }
 
     #[test]
     fn malformed_operation_ids_are_rejected() {
-        for bad in ["", "abc", &"a".repeat(31), &"g".repeat(32), &"a".repeat(33)] {
+        for bad in [
+            "",
+            "abc",
+            "00010a107f80ff4200010a107f80ff42",
+            "00010A107f80ff42-00010a10-7f80ff42",
+            "00010g107f80ff42-00010a10-7f80ff42",
+            "00010a107f80ff4-00010a10-7f80ff42",
+            "00010a107f80ff42-00010a1-7f80ff42",
+            "00010a107f80ff42-00010a10-7f80ff4",
+            "00010a107f80ff42-00010a10-7f80ff42-extra",
+        ] {
             assert_eq!(OperationId::from_str(bad), Err(ParseOperationIdError));
         }
     }
@@ -602,13 +618,21 @@ mod tests {
 
         let unclassified = CoreError::from_domain(
             &crate::Error::Io(std::io::Error::other("boom")),
-            Some(OperationId::from_bytes([7; 16])),
+            Some(OperationId {
+                nanos: 7,
+                pid: 7,
+                counter: 7,
+            }),
         );
         assert_eq!(unclassified.kind, None);
         assert!(!unclassified.retryable);
         assert_eq!(
             unclassified.operation_id,
-            Some(OperationId::from_bytes([7; 16]))
+            Some(OperationId {
+                nanos: 7,
+                pid: 7,
+                counter: 7,
+            })
         );
     }
 

--- a/crates/nyanpasu-core-manager/src/control/mod.rs
+++ b/crates/nyanpasu-core-manager/src/control/mod.rs
@@ -12,14 +12,25 @@
 //!   kind is a statement of fact about the failure and a guessed kind is worse
 //!   than an absent one; unclassified failures stay unclassified.
 
-use std::sync::atomic::{AtomicU32, Ordering};
+mod executor;
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicU32, Ordering},
+};
+
+use camino::Utf8PathBuf;
+use tokio::sync::{Semaphore, broadcast, mpsc, watch};
 
 use crate::{
     error::CoreErrorKind,
-    manager::ApplyOutcome,
-    spec::{CoreSpec, InstanceOptions},
-    state::RevisionId,
+    log::LogFrame,
+    manager::{ApplyOutcome, CoreManager},
+    spec::{CoreSpec, InstanceOptions, InstanceSpec},
+    state::{CoreStatus, RevisionId},
 };
+
+use executor::{Admission, ExecutorContext, ExecutorWork, Registry};
 
 /// Correlation, idempotency, and event-tracing identity of one control
 /// request. Not a lease, a session, or a lock: it never grants ownership and
@@ -157,6 +168,41 @@ pub enum CoreCommand {
     Shutdown,
 }
 
+impl CoreCommand {
+    /// The identity digest the idempotency registry compares: two envelopes
+    /// with the same [`OperationId`] must describe the same work. Config
+    /// bytes, the desired core, and the CAS token are identity; tuning fields
+    /// ([`InstanceOptions`]) deliberately are not.
+    pub fn payload_digest(&self) -> String {
+        use std::fmt::Write;
+        match self {
+            Self::Reconcile(request) => {
+                let mut identity = format!(
+                    "reconcile\0{}\0{}\0{}\0",
+                    request.core.kind,
+                    request.core.binary_path,
+                    request.core.version.as_deref().unwrap_or(""),
+                );
+                for feature in &request.core.features {
+                    identity.push_str(feature);
+                    identity.push('\0');
+                }
+                if let Some(expected) = &request.expected_applied {
+                    let _ = write!(identity, "{expected}");
+                }
+                identity.push('\0');
+                let mut payload = identity.into_bytes();
+                let ConfigInput::Inline { bytes, .. } = &request.config;
+                payload.extend_from_slice(bytes);
+                payload_digest(&payload)
+            }
+            Self::Stop => payload_digest(b"stop"),
+            Self::Recover => payload_digest(b"recover"),
+            Self::Shutdown => payload_digest(b"shutdown"),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct CoreCommandEnvelope {
     pub operation_id: OperationId,
@@ -243,6 +289,250 @@ pub enum OperationState {
     Running,
     Succeeded(OperationOutput),
     Failed(CoreError),
+}
+
+/// Host-boundary configuration of one control plane.
+#[derive(Debug, Clone)]
+pub struct ControlOptions {
+    /// Where portable config bytes are materialized for the path-based
+    /// pipeline underneath. Host-owned; never a caller path.
+    pub source_dir: Utf8PathBuf,
+    /// Working directory for launched cores (data dir with geo assets).
+    pub working_dir: Utf8PathBuf,
+    /// Mutating-operation queue bound; a full queue answers `QueueFull`.
+    pub queue_capacity: usize,
+    /// Most-recent-operations registry bound (idempotency + query window).
+    pub registry_capacity: usize,
+    /// Concurrent advisory checks; further callers wait on the semaphore.
+    pub check_concurrency: usize,
+}
+
+impl ControlOptions {
+    pub fn new(source_dir: Utf8PathBuf, working_dir: Utf8PathBuf) -> Self {
+        Self {
+            source_dir,
+            working_dir,
+            queue_capacity: 16,
+            registry_capacity: 64,
+            check_concurrency: 2,
+        }
+    }
+}
+
+/// How the executor task ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutorExit {
+    /// A `Shutdown` operation completed and the executor drained.
+    Clean,
+    /// The task died without shutting down (panic). The host must treat the
+    /// whole control plane as fatally broken.
+    Died,
+}
+
+/// The portable control plane over one [`CoreManager`] (design §9): submit /
+/// status / subscribe on the outside, one executor task owning every mutating
+/// transaction on the inside. Cheap to clone; all clones share the executor.
+#[derive(Clone)]
+pub struct CoreControl {
+    manager: CoreManager,
+    registry: Arc<Registry>,
+    work_tx: mpsc::Sender<ExecutorWork>,
+    closing: Arc<AtomicBool>,
+    check_semaphore: Arc<Semaphore>,
+    source_dir: Utf8PathBuf,
+    working_dir: Utf8PathBuf,
+    done_rx: watch::Receiver<bool>,
+}
+
+impl CoreControl {
+    /// Wraps a host-built manager and spawns the executor task. The manager
+    /// handle stays usable directly, but every mutating call should go through
+    /// `submit` from here on — the executor owns transaction serialization.
+    pub fn spawn(manager: CoreManager, options: ControlOptions) -> Self {
+        let ControlOptions {
+            source_dir,
+            working_dir,
+            queue_capacity,
+            registry_capacity,
+            check_concurrency,
+        } = options;
+        let registry = Arc::new(Registry::new(registry_capacity));
+        let (work_tx, work_rx) = mpsc::channel(queue_capacity);
+        let (done_tx, done_rx) = watch::channel(false);
+        let context = ExecutorContext {
+            manager: manager.clone(),
+            registry: registry.clone(),
+            source_dir: source_dir.clone(),
+            working_dir: working_dir.clone(),
+        };
+        tokio::spawn(async move {
+            executor::run(work_rx, context).await;
+            let _ = done_tx.send(true);
+        });
+        Self {
+            manager,
+            registry,
+            work_tx,
+            closing: Arc::new(AtomicBool::new(false)),
+            check_semaphore: Arc::new(Semaphore::new(check_concurrency)),
+            source_dir,
+            working_dir,
+            done_rx,
+        }
+    }
+
+    /// Admission is synchronous: closing latch, idempotency, then the bounded
+    /// queue. The returned handle names the operation; dropping it never
+    /// cancels the work.
+    pub fn submit(&self, envelope: CoreCommandEnvelope) -> Result<OperationHandle, CoreError> {
+        let id = envelope.operation_id;
+        if self.closing.load(Ordering::Acquire) {
+            return Err(CoreError::new(
+                CoreErrorKind::ShuttingDown,
+                "the control plane is shutting down",
+                false,
+            )
+            .with_operation(id));
+        }
+        let digest = envelope.command.payload_digest();
+        let state_rx = match self.registry.admit(id, &digest)? {
+            Admission::Existing(state_rx) => state_rx,
+            Admission::Registered(state_rx) => {
+                let is_shutdown = matches!(envelope.command, CoreCommand::Shutdown);
+                match self.work_tx.try_send(ExecutorWork {
+                    id,
+                    command: envelope.command,
+                }) {
+                    Ok(()) => {
+                        if is_shutdown {
+                            self.closing.store(true, Ordering::Release);
+                        }
+                        state_rx
+                    }
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        self.registry.remove(id);
+                        return Err(CoreError::new(
+                            CoreErrorKind::QueueFull,
+                            "the operation queue is full",
+                            true,
+                        )
+                        .with_operation(id));
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                        self.registry.remove(id);
+                        return Err(CoreError::new(
+                            CoreErrorKind::Internal,
+                            "the control executor is gone",
+                            false,
+                        )
+                        .with_operation(id));
+                    }
+                }
+            }
+        };
+        Ok(OperationHandle { id, state_rx })
+    }
+
+    /// Zero-mailbox snapshot read.
+    pub fn status(&self) -> CoreStatus {
+        self.manager.status()
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<CoreStatus> {
+        self.manager.subscribe()
+    }
+
+    pub fn subscribe_logs(&self) -> broadcast::Receiver<Arc<LogFrame>> {
+        self.manager.subscribe_logs()
+    }
+
+    /// The registry's answer for one operation id, or `None` when the entry
+    /// was evicted or never existed. Losing an entry is recoverable by
+    /// design: re-read status, and let the revision CAS block a double apply.
+    pub fn operation(&self, id: OperationId) -> Option<OperationState> {
+        self.registry.get(id)
+    }
+
+    /// Advisory, read-only config validation (amendment A2): bounded
+    /// concurrency, never queued, and never a precondition for any change.
+    pub async fn check(&self, request: CheckRequest) -> Result<(), CoreError> {
+        let _permit = self.check_semaphore.acquire().await.map_err(|_| {
+            CoreError::new(
+                CoreErrorKind::Internal,
+                "the check semaphore is closed",
+                false,
+            )
+        })?;
+        let ConfigInput::Inline { bytes, .. } = &request.config;
+        let file_name = format!("check-source-{}.yaml", payload_digest(bytes));
+        let id = OperationId::generate();
+        let config_path =
+            executor::materialize(&self.source_dir, &file_name, request.config, id).await?;
+        let spec = InstanceSpec {
+            core: request.core,
+            config_path: config_path.clone(),
+            working_dir: self.working_dir.clone(),
+            pid_file: None,
+            options: InstanceOptions::default(),
+        };
+        let result = self.manager.check_config(&spec).await;
+        // Best-effort cleanup; a concurrent same-digest check rewrites the
+        // same bytes, so a failed removal is harmless.
+        let _ = tokio::fs::remove_file(&config_path).await;
+        result.map_err(|error| CoreError::from_domain(&error, None))
+    }
+
+    /// Resolves when the executor task has exited: cleanly after a `Shutdown`
+    /// operation, or [`ExecutorExit::Died`] when it panicked. The host must
+    /// watch this and turn `Died` into a fatal service state.
+    pub async fn until_closed(&self) -> ExecutorExit {
+        let mut done_rx = self.done_rx.clone();
+        loop {
+            if *done_rx.borrow_and_update() {
+                return ExecutorExit::Clean;
+            }
+            if done_rx.changed().await.is_err() {
+                return ExecutorExit::Died;
+            }
+        }
+    }
+}
+
+/// A submitted operation. `wait` consumes the handle and resolves with the
+/// terminal result; `state` polls without consuming. Dropping the handle
+/// leaves the operation running to its safe terminal state.
+#[derive(Debug)]
+pub struct OperationHandle {
+    id: OperationId,
+    state_rx: watch::Receiver<OperationState>,
+}
+
+impl OperationHandle {
+    pub fn id(&self) -> OperationId {
+        self.id
+    }
+
+    pub fn state(&self) -> OperationState {
+        self.state_rx.borrow().clone()
+    }
+
+    pub async fn wait(mut self) -> Result<OperationOutput, CoreError> {
+        loop {
+            match self.state_rx.borrow_and_update().clone() {
+                OperationState::Succeeded(output) => return Ok(output),
+                OperationState::Failed(error) => return Err(error),
+                OperationState::Queued | OperationState::Running => {}
+            }
+            if self.state_rx.changed().await.is_err() {
+                return Err(CoreError::new(
+                    CoreErrorKind::Internal,
+                    "the control executor terminated before the operation completed",
+                    false,
+                )
+                .with_operation(self.id));
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/nyanpasu-core-manager/src/control/mod.rs
+++ b/crates/nyanpasu-core-manager/src/control/mod.rs
@@ -83,7 +83,7 @@ impl std::str::FromStr for OperationId {
             return Err(ParseOperationIdError);
         }
         let mut bytes = [0u8; 16];
-        for (index, chunk) in value.as_bytes().chunks_exact(2).enumerate() {
+        for (index, chunk) in value.as_bytes().as_chunks::<2>().0.iter().enumerate() {
             let chunk = std::str::from_utf8(chunk).map_err(|_| ParseOperationIdError)?;
             bytes[index] = u8::from_str_radix(chunk, 16).map_err(|_| ParseOperationIdError)?;
         }

--- a/crates/nyanpasu-core-manager/src/control/mod.rs
+++ b/crates/nyanpasu-core-manager/src/control/mod.rs
@@ -379,21 +379,26 @@ impl CoreControl {
         )));
         let (work_tx, work_rx) = mpsc::channel(queue_capacity);
         let (done_tx, done_rx) = watch::channel(false);
-        let context = ExecutorContext {
+        let closing = Arc::new(AtomicBool::new(false));
+        let context = Arc::new(ExecutorContext {
             manager: manager.clone(),
             registry: registry.clone(),
             source_dir: source_dir.clone(),
             working_dir: working_dir.clone(),
-        };
+            closing: closing.clone(),
+        });
         tokio::spawn(async move {
-            executor::run(work_rx, context).await;
-            let _ = done_tx.send(true);
+            // Only a clean exit reports done. A dead executor drops `done_tx`
+            // instead, which is what `until_closed` reads as `Died`.
+            if executor::run(work_rx, context).await == ExecutorExit::Clean {
+                let _ = done_tx.send(true);
+            }
         });
         Self {
             manager,
             registry,
             work_tx,
-            closing: Arc::new(AtomicBool::new(false)),
+            closing,
             check_semaphore: Arc::new(Semaphore::new(check_concurrency)),
             source_dir,
             working_dir,

--- a/crates/nyanpasu-core-manager/src/dns.rs
+++ b/crates/nyanpasu-core-manager/src/dns.rs
@@ -1,0 +1,219 @@
+//! Host DNS override as an orchestrator-owned component (amendment A5 ③):
+//! applied and restored at fixed phases of the core lifecycle transaction,
+//! never by the app process.
+//!
+//! Invariants (audit §3):
+//!
+//! - The record is persisted *before* the side effect, so a crash between the
+//!   two leaves an orphan record whose restore is a read-back no-op.
+//! - Apply and restore both advance by read-back: an `Err` from the platform
+//!   command never implies the side effect is absent.
+//! - The manager converges DNS at the tail of every mutating transaction
+//!   (apply when a runtime is up and wants an override, restore otherwise) and
+//!   restores at the head of user-initiated stop/shutdown, so resolution never
+//!   points at a core that is being torn down.
+
+use serde::{Deserialize, Serialize};
+use serde_yaml_ng::Mapping;
+
+use crate::runtime::BoxFuture;
+
+/// The override one host should hold while a given effective config runs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsIntent {
+    /// Interface-scoped resolver addresses, in platform-native spelling.
+    pub servers: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DnsOverrideState {
+    /// Recorded, side effect in flight or in place.
+    Applied,
+    /// Restore started but not yet read back as clean.
+    RestorePending,
+}
+
+/// The persisted proof-of-ownership for one applied override.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DnsOverrideRecord {
+    pub interface: String,
+    /// Read-back before the apply; restore returns the interface here.
+    pub previous: Vec<String>,
+    pub applied: Vec<String>,
+    pub runtime_epoch: u64,
+    /// `ControllerGeneration` when a host layer supplies one; opaque here.
+    pub owner_generation: Option<u64>,
+    pub state: DnsOverrideState,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DnsError {
+    #[error("dns command failed: {0}")]
+    Command(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+/// Platform DNS mechanics behind one narrow boundary. A host without DNS
+/// responsibility simply injects no controller.
+pub trait DnsController: Send + Sync {
+    /// The override this host should hold while `effective` runs, or `None`.
+    ///
+    /// The derivation is controller policy, not orchestrator policy — the
+    /// orchestrator only knows the fixed phases.
+    fn desired(&self, effective: &Mapping) -> Option<DnsIntent>;
+
+    /// Applies `intent` and reads the result back. Must be idempotent: the
+    /// converge tail calls this after every mutating transaction. Returns the
+    /// record to persist (with `previous` captured by read-back).
+    fn apply<'a>(
+        &'a self,
+        intent: &'a DnsIntent,
+        runtime_epoch: u64,
+    ) -> BoxFuture<'a, Result<DnsOverrideRecord, DnsError>>;
+
+    /// Restores `record.previous` and reads the result back. Also the orphan
+    /// reconcile path at manager construction — restore of a record whose
+    /// side effect never landed must read back as an immediate no-op.
+    fn restore<'a>(&'a self, record: &'a DnsOverrideRecord) -> BoxFuture<'a, Result<(), DnsError>>;
+}
+
+/// macOS implementation sketch. **Unverified on this branch** — written on a
+/// Windows host where `cfg(target_os = "macos")` code is never compiled or
+/// run; the Phase-0 spike on real macOS decides the mechanism and hardens
+/// this.
+///
+/// Mechanism choice (audit §3, design §8): a `scutil` dynamic-store `State:`
+/// key expresses *structural ownership* — creating
+/// `State:/Network/Service/<id>/DNS` overrides resolution, deleting the key
+/// restores it, and the key cannot survive a reboot. That beats
+/// `networksetup -setdnsservers`, whose only restore is writing back a
+/// remembered value that may have changed underneath.
+///
+/// Phase-0 acceptance criteria (machine-checkable, run on macOS):
+/// 1. after writing the key, `scutil --dns` lists the override as the first
+///    resolver;
+/// 2. after deleting the key, `scutil --dns` shows the pre-override resolver;
+/// 3. after a reboot with the key left in place, the key does not exist.
+#[cfg(target_os = "macos")]
+pub mod macos {
+    use super::*;
+
+    pub struct MacosDnsController {
+        /// The dynamic-store key this controller owns, e.g.
+        /// `State:/Network/Service/nyanpasu-dns/DNS`.
+        store_key: String,
+    }
+
+    impl MacosDnsController {
+        pub fn new(store_key: String) -> Self {
+            Self { store_key }
+        }
+
+        async fn scutil(script: String) -> Result<String, DnsError> {
+            use tokio::io::AsyncWriteExt;
+            let mut child = tokio::process::Command::new("/usr/sbin/scutil")
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()?;
+            child
+                .stdin
+                .as_mut()
+                .expect("stdin was piped")
+                .write_all(script.as_bytes())
+                .await?;
+            let output = child.wait_with_output().await?;
+            if !output.status.success() {
+                return Err(DnsError::Command(
+                    String::from_utf8_lossy(&output.stderr).into_owned(),
+                ));
+            }
+            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        }
+
+        /// Read-back: does the owned key currently exist with `servers`?
+        async fn read_back(&self) -> Result<Option<Vec<String>>, DnsError> {
+            let output = Self::scutil(format!("show {}\n", self.store_key)).await?;
+            if output.contains("No such key") {
+                return Ok(None);
+            }
+            let servers = output
+                .lines()
+                .filter_map(|line| {
+                    let trimmed = line.trim();
+                    trimmed
+                        .split_once(':')
+                        .filter(|(key, _)| key.trim().chars().all(|c| c.is_ascii_digit()))
+                        .map(|(_, value)| value.trim().to_owned())
+                })
+                .collect();
+            Ok(Some(servers))
+        }
+    }
+
+    impl DnsController for MacosDnsController {
+        fn desired(&self, effective: &Mapping) -> Option<DnsIntent> {
+            // Placeholder product rule, finalized with the app wiring (PR-D):
+            // only a DNS server the OS can actually reach on port 53 is worth
+            // pointing the system at.
+            let dns = effective.get("dns")?.as_mapping()?;
+            if !dns.get("enable")?.as_bool()? {
+                return None;
+            }
+            let listen = dns.get("listen")?.as_str()?;
+            let port = listen.rsplit_once(':')?.1;
+            (port == "53").then(|| DnsIntent {
+                servers: vec!["127.0.0.1".to_owned()],
+            })
+        }
+
+        fn apply<'a>(
+            &'a self,
+            intent: &'a DnsIntent,
+            runtime_epoch: u64,
+        ) -> BoxFuture<'a, Result<DnsOverrideRecord, DnsError>> {
+            Box::pin(async move {
+                let previous = self.read_back().await?.unwrap_or_default();
+                let addresses = intent.servers.join(" ");
+                Self::scutil(format!(
+                    "d.init\nd.add ServerAddresses * {addresses}\nset {}\n",
+                    self.store_key
+                ))
+                .await?;
+                let observed = self.read_back().await?;
+                if observed.as_deref() != Some(intent.servers.as_slice()) {
+                    return Err(DnsError::Command(format!(
+                        "read-back mismatch after apply: {observed:?}"
+                    )));
+                }
+                Ok(DnsOverrideRecord {
+                    interface: self.store_key.clone(),
+                    previous,
+                    applied: intent.servers.clone(),
+                    runtime_epoch,
+                    owner_generation: None,
+                    state: DnsOverrideState::Applied,
+                })
+            })
+        }
+
+        fn restore<'a>(
+            &'a self,
+            _record: &'a DnsOverrideRecord,
+        ) -> BoxFuture<'a, Result<(), DnsError>> {
+            Box::pin(async move {
+                // Structural restore: delete the owned key. No remembered
+                // value can be stale because nothing is written back.
+                Self::scutil(format!("remove {}\n", self.store_key)).await?;
+                if self.read_back().await?.is_some() {
+                    return Err(DnsError::Command(
+                        "read-back still shows the override after restore".into(),
+                    ));
+                }
+                Ok(())
+            })
+        }
+    }
+}

--- a/crates/nyanpasu-core-manager/src/dns.rs
+++ b/crates/nyanpasu-core-manager/src/dns.rs
@@ -57,6 +57,26 @@ pub enum DnsError {
 
 /// Platform DNS mechanics behind one narrow boundary. A host without DNS
 /// responsibility simply injects no controller.
+///
+/// **Contract limit (audit L8).** This shape supports *structurally owned*
+/// overrides only: ones whose restore removes an artifact the controller owns
+/// and therefore does not replay `record.previous`. The orchestrator persists
+/// its pre-record before the first `apply`, and on that first call the record
+/// has no baseline yet — nothing has read one back. A write-back controller
+/// (`networksetup -setdnsservers` and friends), whose restore *is* replaying
+/// the remembered value, would be unrecoverable in exactly that window: side
+/// effect landed, `apply` never returned, nothing recorded to write back.
+///
+/// Adding one therefore requires splitting `apply` into prepare (read back the
+/// baseline, hand it to the orchestrator to persist) and commit, which is the
+/// L8 migration. Until then, do not implement this trait with a write-back
+/// mechanism.
+///
+/// Each call is bounded by
+/// [`ManagerOptions::dns_timeout`](crate::spec::ManagerOptions::dns_timeout).
+/// An implementation must therefore be cancel-safe in the weak sense the
+/// orchestrator relies on: a dropped future may leave the side effect in place,
+/// and it is treated as uncertain rather than absent.
 pub trait DnsController: Send + Sync {
     /// The override this host should hold while `effective` runs, or `None`.
     ///
@@ -117,6 +137,9 @@ pub mod macos {
                 .stdin(std::process::Stdio::piped())
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
+                // The orchestrator bounds this call and drops the future on
+                // timeout; without this the child would outlive it.
+                .kill_on_drop(true)
                 .spawn()?;
             child
                 .stdin

--- a/crates/nyanpasu-core-manager/src/lib.rs
+++ b/crates/nyanpasu-core-manager/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod capability;
 mod config;
+pub mod control;
 mod error;
 mod health;
 pub mod instance;
@@ -18,6 +19,10 @@ pub mod state;
 pub use capability::{Feature, RuntimeFeature};
 pub use clash_api::Host;
 pub use config::runtime_store;
+pub use control::{
+    CheckRequest, ConfigInput, CoreCommand, CoreCommandEnvelope, CoreError, OperationId,
+    OperationOutput, OperationState, ReconcileRequest, payload_digest,
+};
 pub use error::{CoreErrorKind, Error};
 pub use health::{HealthPolicy, probe};
 pub use instance::{Instance, InstanceBuilder};

--- a/crates/nyanpasu-core-manager/src/lib.rs
+++ b/crates/nyanpasu-core-manager/src/lib.rs
@@ -6,6 +6,7 @@
 mod capability;
 mod config;
 pub mod control;
+pub mod dns;
 mod error;
 mod health;
 pub mod instance;
@@ -25,6 +26,7 @@ pub use control::{
     CoreError, ExecutorExit, OperationHandle, OperationId, OperationOutput, OperationState,
     ReconcileRequest, payload_digest,
 };
+pub use dns::{DnsController, DnsError, DnsIntent, DnsOverrideRecord, DnsOverrideState};
 pub use error::{CoreErrorKind, Error};
 pub use health::{HealthPolicy, probe};
 pub use instance::{Instance, InstanceBuilder};

--- a/crates/nyanpasu-core-manager/src/lib.rs
+++ b/crates/nyanpasu-core-manager/src/lib.rs
@@ -21,8 +21,9 @@ pub use capability::{Feature, RuntimeFeature};
 pub use clash_api::Host;
 pub use config::runtime_store;
 pub use control::{
-    CheckRequest, ConfigInput, CoreCommand, CoreCommandEnvelope, CoreError, OperationId,
-    OperationOutput, OperationState, ReconcileRequest, payload_digest,
+    CheckRequest, ConfigInput, ControlOptions, CoreCommand, CoreCommandEnvelope, CoreControl,
+    CoreError, ExecutorExit, OperationHandle, OperationId, OperationOutput, OperationState,
+    ReconcileRequest, payload_digest,
 };
 pub use error::{CoreErrorKind, Error};
 pub use health::{HealthPolicy, probe};

--- a/crates/nyanpasu-core-manager/src/lib.rs
+++ b/crates/nyanpasu-core-manager/src/lib.rs
@@ -13,6 +13,7 @@ pub mod kind;
 mod log;
 mod log_sink;
 pub mod manager;
+pub mod runtime;
 pub mod spec;
 pub mod state;
 
@@ -33,6 +34,7 @@ pub use probe::{
     ControllerVersionProbe, HealthProbe, ProbeContext, ProbeFuture, ProbeHandle, ProbePhase,
     ProbeResult,
 };
+pub use runtime::{RuntimeBackend, RuntimeInstance, RuntimeLaunchRequest};
 pub use runtime_store::{
     RuntimeCommitDurability, RuntimeConfigBackup, RuntimeConfigCommit, RuntimeConfigStore,
     StagedRuntimeConfig,

--- a/crates/nyanpasu-core-manager/src/manager/apply.rs
+++ b/crates/nyanpasu-core-manager/src/manager/apply.rs
@@ -23,6 +23,17 @@ impl CoreManager {
     ) -> Result<ApplyOutcome, Error> {
         let mut ctrl = self.inner.ctrl.lock().await;
         reject_quarantine(&ctrl)?;
+        self.apply_locked(&mut ctrl, input, expected_revision).await
+    }
+
+    /// The running-core apply transaction, entered with the control lock held.
+    /// Shared by [`Self::apply_config`] and [`CoreManager::reconcile`].
+    pub(super) async fn apply_locked(
+        &self,
+        ctrl: &mut Ctrl,
+        input: InstanceSpec,
+        expected_revision: Option<RevisionId>,
+    ) -> Result<ApplyOutcome, Error> {
         let current = ctrl.current.as_ref().ok_or(Error::NotStarted)?;
         if current.instance.state().borrow().state.is_terminal() {
             return Err(Error::NotStarted);
@@ -56,9 +67,7 @@ impl CoreManager {
         }
         if matches!(change, ConfigChange::Switch) {
             drop(prepared);
-            return self
-                .switch_with_compensation(&mut ctrl, input, snapshot)
-                .await;
+            return self.switch_with_compensation(ctrl, input, snapshot).await;
         }
 
         let backup = self
@@ -142,9 +151,7 @@ impl CoreManager {
             return Ok(with_durability_warning(outcome, durability_warning));
         }
 
-        let result = self
-            .restart_with_compensation(&mut ctrl, desired, backup)
-            .await;
+        let result = self.restart_with_compensation(ctrl, desired, backup).await;
         with_durability_result(result, durability_warning)
     }
 

--- a/crates/nyanpasu-core-manager/src/manager/apply.rs
+++ b/crates/nyanpasu-core-manager/src/manager/apply.rs
@@ -4,8 +4,8 @@ use crate::{
         mihomo::{self, ConfigChange},
     },
     error::Error,
-    instance::Instance,
     probe::ProbePhase,
+    runtime::RuntimeInstance,
     spec::InstanceSpec,
     state::{ConfigRevision, CoreState, RevisionId},
 };
@@ -171,7 +171,7 @@ impl CoreManager {
         let staged = self.inner.store.stage(epoch, &prepared.bytes).await?;
         let mut check_spec = input.clone();
         check_spec.config_path = staged.path().to_owned();
-        crate::kind::check_config(&check_spec).await?;
+        self.inner.backend.check_config(&check_spec).await?;
 
         let runtime_path = current.revision.runtime_path.clone();
         let mut effective_spec = input.clone();
@@ -204,7 +204,7 @@ impl CoreManager {
     ) -> bool {
         if let ConfigChange::Patch { patch, projection } = change {
             return self
-                .patch_and_verify(&current.instance, patch, projection)
+                .patch_and_verify(current.instance.as_ref(), patch, projection)
                 .await;
         }
         if matches!(change, ConfigChange::Switch) {
@@ -249,7 +249,7 @@ impl CoreManager {
 
     pub(super) async fn patch_and_verify(
         &self,
-        instance: &Instance,
+        instance: &dyn RuntimeInstance,
         patch: &clash_api::ConfigPatch,
         projection: &mihomo::RuntimeProjection,
     ) -> bool {

--- a/crates/nyanpasu-core-manager/src/manager/dns_sync.rs
+++ b/crates/nyanpasu-core-manager/src/manager/dns_sync.rs
@@ -10,6 +10,14 @@
 //! It is logged, the record is kept (so a later restore can still undo it),
 //! and the caller's outcome is unchanged. Read-back lives inside the
 //! controller; an `Err` here never implies the side effect is absent.
+//!
+//! One asymmetry, and it is the crash-recovery guarantee rather than a
+//! preference: applying an override is refused when the record cannot be
+//! written, because an override nothing recorded is an override nothing can
+//! undo. Restoring is never blocked by a persistence failure — it is the safe
+//! direction.
+
+use std::{io, time::Duration};
 
 use crate::{
     dns::{DnsController, DnsOverrideRecord, DnsOverrideState},
@@ -19,13 +27,19 @@ use crate::{
 use super::{CoreManager, Ctrl};
 
 const RECORD_FILE: &str = "dns-override.json";
+const RECORD_STAGING_FILE: &str = "dns-override.json.tmp";
 
 /// Startup orphan reconcile: a record left behind by a dead process is
 /// restored (a no-op when its side effect never landed) and cleared. Runs
 /// before the manager exists, so it takes the store directly.
+///
+/// Bounded by the same `dns_timeout` as the converge tail: this runs inside
+/// manager construction, and a platform command that never returns would hang
+/// the daemon before it ever serves.
 pub(super) async fn reconcile_orphan_record(
     store: &RuntimeConfigStore,
     dns: Option<&dyn DnsController>,
+    dns_timeout: Duration,
 ) {
     let path = store.dir().join(RECORD_FILE);
     let Ok(bytes) = tokio::fs::read(&path).await else {
@@ -44,15 +58,18 @@ pub(super) async fn reconcile_orphan_record(
         );
         return;
     };
-    match dns.restore(&record).await {
-        Ok(()) => {
+    match tokio::time::timeout(dns_timeout, dns.restore(&record)).await {
+        Ok(Ok(())) => {
             if let Err(error) = tokio::fs::remove_file(&path).await {
                 tracing::warn!("failed to clear the restored dns override record: {error}");
             }
         }
-        Err(error) => {
+        Ok(Err(error)) => {
             tracing::warn!("orphan dns override restore failed; keeping the record: {error}");
         }
+        Err(_) => tracing::warn!(
+            "orphan dns override restore timed out after {dns_timeout:?}; keeping the record"
+        ),
     }
 }
 
@@ -76,24 +93,69 @@ impl CoreManager {
             self.dns_restore(ctrl).await;
             return;
         };
+
+        // The baseline is captured once, on the converge that first took
+        // ownership. Every later converge re-applies over an interface that
+        // already carries *our* override, so the controller's read-back would
+        // report the override itself as the thing to restore to.
+        //
+        // A non-empty `interface` is the discriminator, because only a
+        // successful read-back supplies one -- the pre-record written before
+        // the first apply deliberately leaves it empty. An empty `previous` is
+        // a legitimate baseline (an interface with no resolvers), and
+        // `RestorePending` still owns the baseline: it says the restore is
+        // uncertain, not that what we recorded stopped being true.
+        let baseline = ctrl
+            .dns_record
+            .as_ref()
+            .filter(|record| !record.interface.is_empty())
+            .map(|record| (record.interface.clone(), record.previous.clone()));
+
         // Persist a pre-record before the side effect: a crash between the
         // two leaves an orphan whose restore is a read-back no-op.
         let pre_record = DnsOverrideRecord {
-            interface: String::new(),
-            previous: Vec::new(),
+            interface: baseline
+                .as_ref()
+                .map_or_else(String::new, |(interface, _)| interface.clone()),
+            previous: baseline
+                .as_ref()
+                .map_or_else(Vec::new, |(_, previous)| previous.clone()),
             applied: intent.servers.clone(),
             runtime_epoch: epoch,
             owner_generation: None,
             state: DnsOverrideState::Applied,
         };
-        self.persist_dns_record(ctrl, Some(pre_record)).await;
-        match dns.apply(&intent, epoch).await {
-            Ok(record) => self.persist_dns_record(ctrl, Some(record)).await,
-            Err(error) => {
-                // Keep the pre-record: the side effect is uncertain, and a
-                // later restore must still be able to undo it.
-                tracing::warn!("dns override apply failed; keeping the pre-record: {error}");
+        if let Err(error) = self.persist_dns_record(ctrl, Some(pre_record)).await {
+            tracing::warn!("the dns override record is unwritable; skipping the override: {error}");
+            return;
+        }
+
+        let dns_timeout = self.inner.options.dns_timeout;
+        match tokio::time::timeout(dns_timeout, dns.apply(&intent, epoch)).await {
+            Ok(Ok(mut record)) => {
+                if let Some((interface, previous)) = baseline {
+                    if record.interface != interface {
+                        tracing::warn!(
+                            "the dns interface changed under the override; keeping the recorded baseline"
+                        );
+                        return;
+                    }
+                    record.previous = previous;
+                }
+                if let Err(error) = self.persist_dns_record(ctrl, Some(record)).await {
+                    tracing::warn!(
+                        "failed to persist the dns read-back; keeping the pre-record: {error}"
+                    );
+                }
             }
+            // The side effect is uncertain either way, so the pre-record stays:
+            // a later restore must still be able to undo it.
+            Ok(Err(error)) => {
+                tracing::warn!("dns override apply failed; keeping the pre-record: {error}")
+            }
+            Err(_) => tracing::warn!(
+                "dns override apply timed out after {dns_timeout:?}; keeping the pre-record"
+            ),
         }
     }
 
@@ -109,37 +171,96 @@ impl CoreManager {
         };
         let mut pending = record.clone();
         pending.state = DnsOverrideState::RestorePending;
-        self.persist_dns_record(ctrl, Some(pending)).await;
-        match dns.restore(&record).await {
-            Ok(()) => self.persist_dns_record(ctrl, None).await,
-            Err(error) => {
-                tracing::warn!("dns override restore failed; keeping the record: {error}");
+        if let Err(error) = self.persist_dns_record(ctrl, Some(pending)).await {
+            // Undoing an override is the safe direction; a record that cannot
+            // be updated must not keep the system pointed at a dead core.
+            tracing::warn!("failed to mark the dns override restore-pending: {error}");
+        }
+        let dns_timeout = self.inner.options.dns_timeout;
+        match tokio::time::timeout(dns_timeout, dns.restore(&record)).await {
+            Ok(Ok(())) => {
+                if let Err(error) = self.persist_dns_record(ctrl, None).await {
+                    tracing::warn!("dns was restored but its record could not be cleared: {error}");
+                }
             }
+            Ok(Err(error)) => {
+                tracing::warn!("dns override restore failed; keeping the record: {error}")
+            }
+            Err(_) => tracing::warn!(
+                "dns override restore timed out after {dns_timeout:?}; keeping the record"
+            ),
         }
     }
 
-    /// Record-before-side-effect persistence. Failures are logged, never
-    /// propagated: losing the record loses crash recovery, not correctness of
-    /// the running transaction.
-    async fn persist_dns_record(&self, ctrl: &mut Ctrl, record: Option<DnsOverrideRecord>) {
-        let path = self.inner.store.dir().join(RECORD_FILE);
-        let result = match &record {
-            Some(entry) => match serde_json::to_vec_pretty(entry) {
-                Ok(bytes) => tokio::fs::write(&path, bytes).await,
-                Err(error) => {
-                    tracing::warn!("failed to encode the dns override record: {error}");
-                    ctrl.dns_record = record;
-                    return;
+    /// Record-before-side-effect persistence, durably: a torn write would
+    /// leave an orphan record that cannot be parsed and therefore cannot be
+    /// undone, and an unsynced one could vanish in the crash it exists to
+    /// survive. Same protocol as [`RuntimeConfigStore`](crate::runtime_store):
+    /// write, flush and `sync_all` a staging file, publish it atomically, then
+    /// sync the directory entry.
+    ///
+    /// In-memory state advances once the record is *visible* -- after the
+    /// rename, not after the directory sync. A failed directory sync leaves a
+    /// readable record behind, so pretending we do not own it would be the
+    /// bigger lie; it is reported and the ownership stands.
+    async fn persist_dns_record(
+        &self,
+        ctrl: &mut Ctrl,
+        record: Option<DnsOverrideRecord>,
+    ) -> io::Result<()> {
+        use nyanpasu_utils::io::atomic_fs;
+        use tokio::io::AsyncWriteExt;
+
+        let dir = self.inner.store.dir();
+        let path = dir.join(RECORD_FILE);
+        match &record {
+            Some(entry) => {
+                let staging = dir.join(RECORD_STAGING_FILE);
+                let result = async {
+                    let bytes = serde_json::to_vec_pretty(entry).map_err(io::Error::other)?;
+                    let mut file = tokio::fs::File::create(&staging).await?;
+                    file.write_all(&bytes).await?;
+                    file.flush().await?;
+                    file.sync_all().await?;
+                    drop(file);
+                    // Same split as the runtime config store: `atomic_replace`
+                    // requires an existing target on Windows, `atomic_move_new`
+                    // requires an absent one. The runtime directory is held
+                    // under an ownership lock, so nothing else publishes here.
+                    // A `try_exists` failure is propagated rather than read as
+                    // "absent": we cannot publish safely into a directory we
+                    // cannot stat.
+                    if tokio::fs::try_exists(&path).await? {
+                        atomic_fs::atomic_replace(&staging, &path).await
+                    } else {
+                        atomic_fs::atomic_move_new(&staging, &path).await
+                    }
+                    .map_err(io::Error::other)
                 }
-            },
+                .await;
+                if let Err(error) = result {
+                    let _ = tokio::fs::remove_file(&staging).await;
+                    return Err(error);
+                }
+                if let Err(error) = atomic_fs::sync_dir(dir).await {
+                    tracing::warn!(
+                        "the dns override record is published but its directory entry is unsynced: {error}"
+                    );
+                }
+            }
             None => match tokio::fs::remove_file(&path).await {
-                Err(error) if error.kind() != std::io::ErrorKind::NotFound => Err(error),
-                _ => Ok(()),
+                Ok(()) => {
+                    if let Err(error) = atomic_fs::sync_dir(dir).await {
+                        tracing::warn!(
+                            "the dns override record is removed but its directory entry is unsynced: {error}"
+                        );
+                    }
+                }
+                Err(error) if error.kind() != io::ErrorKind::NotFound => return Err(error),
+                Err(_) => {}
             },
-        };
-        if let Err(error) = result {
-            tracing::warn!("failed to persist the dns override record: {error}");
         }
         ctrl.dns_record = record;
+        Ok(())
     }
 }

--- a/crates/nyanpasu-core-manager/src/manager/dns_sync.rs
+++ b/crates/nyanpasu-core-manager/src/manager/dns_sync.rs
@@ -1,0 +1,145 @@
+//! DNS override convergence at the fixed phases of the v2 transaction entry
+//! points (`reconcile` / `stop` / `shutdown` / `recover_quarantine`).
+//!
+//! The legacy v1 methods (`start` / `apply_config` / `switch` / `restart`)
+//! deliberately do *not* converge DNS: under v1 the app process owns DNS
+//! behavior, and that stays untouched until the bridge-cleanup stage removes
+//! v1 entirely.
+//!
+//! Failure policy: a DNS failure never fails the core lifecycle transaction.
+//! It is logged, the record is kept (so a later restore can still undo it),
+//! and the caller's outcome is unchanged. Read-back lives inside the
+//! controller; an `Err` here never implies the side effect is absent.
+
+use crate::{
+    dns::{DnsController, DnsOverrideRecord, DnsOverrideState},
+    runtime_store::RuntimeConfigStore,
+};
+
+use super::{CoreManager, Ctrl};
+
+const RECORD_FILE: &str = "dns-override.json";
+
+/// Startup orphan reconcile: a record left behind by a dead process is
+/// restored (a no-op when its side effect never landed) and cleared. Runs
+/// before the manager exists, so it takes the store directly.
+pub(super) async fn reconcile_orphan_record(
+    store: &RuntimeConfigStore,
+    dns: Option<&dyn DnsController>,
+) {
+    let path = store.dir().join(RECORD_FILE);
+    let Ok(bytes) = tokio::fs::read(&path).await else {
+        return;
+    };
+    let record = match serde_json::from_slice::<DnsOverrideRecord>(&bytes) {
+        Ok(record) => record,
+        Err(error) => {
+            tracing::warn!("unreadable orphan dns override record; keeping the file: {error}");
+            return;
+        }
+    };
+    let Some(dns) = dns else {
+        tracing::warn!(
+            "an orphan dns override record exists but no dns controller is injected; keeping it"
+        );
+        return;
+    };
+    match dns.restore(&record).await {
+        Ok(()) => {
+            if let Err(error) = tokio::fs::remove_file(&path).await {
+                tracing::warn!("failed to clear the restored dns override record: {error}");
+            }
+        }
+        Err(error) => {
+            tracing::warn!("orphan dns override restore failed; keeping the record: {error}");
+        }
+    }
+}
+
+impl CoreManager {
+    /// Converge tail: apply the override when a runtime is up and wants one,
+    /// restore otherwise. Idempotent; called with the control lock held.
+    pub(super) async fn dns_converge(&self, ctrl: &mut Ctrl) {
+        let Some(dns) = self.inner.dns.clone() else {
+            return;
+        };
+        let desired = ctrl.current.as_ref().and_then(|active| {
+            let running = !active.instance.state().borrow().state.is_terminal();
+            running
+                .then(|| {
+                    dns.desired(&active.effective_document)
+                        .map(|intent| (intent, active.instance.epoch()))
+                })
+                .flatten()
+        });
+        let Some((intent, epoch)) = desired else {
+            self.dns_restore(ctrl).await;
+            return;
+        };
+        // Persist a pre-record before the side effect: a crash between the
+        // two leaves an orphan whose restore is a read-back no-op.
+        let pre_record = DnsOverrideRecord {
+            interface: String::new(),
+            previous: Vec::new(),
+            applied: intent.servers.clone(),
+            runtime_epoch: epoch,
+            owner_generation: None,
+            state: DnsOverrideState::Applied,
+        };
+        self.persist_dns_record(ctrl, Some(pre_record)).await;
+        match dns.apply(&intent, epoch).await {
+            Ok(record) => self.persist_dns_record(ctrl, Some(record)).await,
+            Err(error) => {
+                // Keep the pre-record: the side effect is uncertain, and a
+                // later restore must still be able to undo it.
+                tracing::warn!("dns override apply failed; keeping the pre-record: {error}");
+            }
+        }
+    }
+
+    /// Restore head/tail: undo the recorded override and clear the record.
+    /// Called at the head of stop/shutdown (so resolution never points at a
+    /// core being torn down) and from the converge tail when nothing runs.
+    pub(super) async fn dns_restore(&self, ctrl: &mut Ctrl) {
+        let Some(dns) = self.inner.dns.clone() else {
+            return;
+        };
+        let Some(record) = ctrl.dns_record.clone() else {
+            return;
+        };
+        let mut pending = record.clone();
+        pending.state = DnsOverrideState::RestorePending;
+        self.persist_dns_record(ctrl, Some(pending)).await;
+        match dns.restore(&record).await {
+            Ok(()) => self.persist_dns_record(ctrl, None).await,
+            Err(error) => {
+                tracing::warn!("dns override restore failed; keeping the record: {error}");
+            }
+        }
+    }
+
+    /// Record-before-side-effect persistence. Failures are logged, never
+    /// propagated: losing the record loses crash recovery, not correctness of
+    /// the running transaction.
+    async fn persist_dns_record(&self, ctrl: &mut Ctrl, record: Option<DnsOverrideRecord>) {
+        let path = self.inner.store.dir().join(RECORD_FILE);
+        let result = match &record {
+            Some(entry) => match serde_json::to_vec_pretty(entry) {
+                Ok(bytes) => tokio::fs::write(&path, bytes).await,
+                Err(error) => {
+                    tracing::warn!("failed to encode the dns override record: {error}");
+                    ctrl.dns_record = record;
+                    return;
+                }
+            },
+            None => match tokio::fs::remove_file(&path).await {
+                Err(error) if error.kind() != std::io::ErrorKind::NotFound => Err(error),
+                _ => Ok(()),
+            },
+        };
+        if let Err(error) = result {
+            tracing::warn!("failed to persist the dns override record: {error}");
+        }
+        ctrl.dns_record = record;
+    }
+}

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -20,10 +20,13 @@ use crate::{
     capability::{ResolvedFeatures, VersionCache},
     config::{self, ConfigSnapshot, mihomo},
     error::Error,
-    instance::Instance,
     log::{LOG_CHANNEL_CAPACITY, LogFrame},
     log_sink::{self, SinkOptions},
     probe::ProbeHandle,
+    runtime::{
+        RuntimeBackend, RuntimeInstance, RuntimeLaunchRequest,
+        process::{ProbePlan, ProcessRuntimeBackend},
+    },
     runtime_store::{RuntimeConfigStore, RuntimeDirectoryLock, StagedRuntimeConfig},
     spec::{CoreSpec, InstanceSpec, LocalIpcPolicy, ManagerOptions, ResolvedController},
     state::{ConfigRevision, CoreState, CoreStatus, InstanceStatus, StopReason},
@@ -91,18 +94,12 @@ pub struct CoreManager {
 pub struct CoreManagerBuilder {
     options: ManagerOptions,
     probes: ProbePlan,
-}
-
-#[derive(Clone, Default)]
-struct ProbePlan {
-    readiness: Option<ProbeHandle>,
-    liveness: Option<ProbeHandle>,
-    liveness_with_readiness: bool,
+    backend: Option<Arc<dyn RuntimeBackend>>,
 }
 
 struct Inner {
     options: ManagerOptions,
-    probes: ProbePlan,
+    backend: Arc<dyn RuntimeBackend>,
     store: RuntimeConfigStore,
     ctrl: tokio::sync::Mutex<Ctrl>,
     status_tx: watch::Sender<CoreStatus>,
@@ -139,7 +136,7 @@ struct QuarantinedEpoch {
 }
 
 struct Active {
-    instance: Instance,
+    instance: Box<dyn RuntimeInstance>,
     forwarder: tokio::task::JoinHandle<()>,
     source_spec: InstanceSpec,
     revision: ConfigRevision,
@@ -196,6 +193,14 @@ impl CoreManagerBuilder {
         self
     }
 
+    /// Replaces the default process backend. The probe methods on this builder
+    /// configure the default backend only; a custom backend owns its own
+    /// probing.
+    pub fn runtime_backend(mut self, backend: Arc<dyn RuntimeBackend>) -> Self {
+        self.backend = Some(backend);
+        self
+    }
+
     pub async fn build(self) -> Result<CoreManager, Error> {
         CoreManager::build_configured(self).await
     }
@@ -206,6 +211,7 @@ impl CoreManager {
         CoreManagerBuilder {
             options,
             probes: ProbePlan::default(),
+            backend: None,
         }
     }
 
@@ -214,7 +220,11 @@ impl CoreManager {
     }
 
     async fn build_configured(builder: CoreManagerBuilder) -> Result<Self, Error> {
-        let CoreManagerBuilder { options, probes } = builder;
+        let CoreManagerBuilder {
+            options,
+            probes,
+            backend,
+        } = builder;
         let runtime_dir = options
             .runtime_dir
             .clone()
@@ -272,10 +282,16 @@ impl CoreManager {
         } else {
             (None, None)
         };
+        let backend = backend.unwrap_or_else(|| {
+            Arc::new(ProcessRuntimeBackend::new(
+                probes,
+                options.cancel_token.clone(),
+            ))
+        });
         Ok(Self {
             inner: Arc::new(Inner {
                 options,
-                probes,
+                backend,
                 store,
                 ctrl: tokio::sync::Mutex::default(),
                 status_tx,
@@ -409,7 +425,7 @@ impl CoreManager {
 
         let pid = instance.pid().unwrap_or_default();
         self.inner.publish_instance(
-            &instance,
+            instance.as_ref(),
             CoreState::Running { epoch, pid },
             &prepared.source_spec,
             &prepared.revision,
@@ -507,7 +523,7 @@ impl CoreManager {
     }
 
     pub async fn check_config(&self, spec: &InstanceSpec) -> Result<(), Error> {
-        crate::kind::check_config(spec).await
+        self.inner.backend.check_config(spec).await
     }
 
     async fn resolve_features(&self, core: &CoreSpec) -> Result<ResolvedFeatures, Error> {
@@ -603,24 +619,16 @@ impl CoreManager {
         effective_spec: InstanceSpec,
         epoch: u64,
         controller: ResolvedController,
-    ) -> Result<Instance, Error> {
-        let mut builder = Instance::builder(
-            effective_spec,
-            epoch,
-            controller,
-            self.inner.options.cancel_token.clone(),
-        )
-        .log_sender(self.inner.log_tx.clone());
-        if let Some(probe) = self.inner.probes.readiness.clone() {
-            builder = builder.readiness_probe(probe);
-        }
-        if let Some(probe) = self.inner.probes.liveness.clone() {
-            builder = builder.liveness_probe(probe);
-        }
-        if self.inner.probes.liveness_with_readiness {
-            builder = builder.liveness_with_readiness_probe();
-        }
-        builder.spawn().await
+    ) -> Result<Box<dyn RuntimeInstance>, Error> {
+        self.inner
+            .backend
+            .launch(RuntimeLaunchRequest {
+                effective_spec,
+                epoch,
+                controller,
+                log_tx: self.inner.log_tx.clone(),
+            })
+            .await
     }
 }
 

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -266,6 +266,7 @@ impl CoreManager {
             ("control_timeout", options.control_timeout),
             ("reconcile_timeout", options.reconcile_timeout),
             ("stop_timeout", options.stop_timeout),
+            ("dns_timeout", options.dns_timeout),
         ] {
             if timeout.is_zero() {
                 return Err(Error::InvalidManagerOptions(format!(
@@ -287,7 +288,7 @@ impl CoreManager {
             ));
         }
         let max_epoch = sweep_orphans(&store).await?;
-        dns_sync::reconcile_orphan_record(&store, dns.as_deref()).await;
+        dns_sync::reconcile_orphan_record(&store, dns.as_deref(), options.dns_timeout).await;
         let (status_tx, _) = watch::channel(CoreStatus::initial());
         let (log_tx, _) = broadcast::channel(LOG_CHANNEL_CAPACITY);
         // Subscribed here rather than inside the task, and before any instance

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -94,6 +94,8 @@ pub enum ApplyOutcome {
     },
 }
 
+/// A cheap-to-clone handle; every clone shares the same orchestrator state.
+#[derive(Clone)]
 pub struct CoreManager {
     inner: Arc<Inner>,
 }

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -2,6 +2,7 @@
 //! atomic status publication.
 
 mod apply;
+mod dns_sync;
 mod publish;
 mod quarantine;
 mod reconcile;
@@ -20,6 +21,7 @@ use crate::{
     Feature, RuntimeFeature,
     capability::{ResolvedFeatures, VersionCache},
     config::{self, ConfigSnapshot, mihomo},
+    dns::{DnsController, DnsOverrideRecord},
     error::Error,
     log::{LOG_CHANNEL_CAPACITY, LogFrame},
     log_sink::{self, SinkOptions},
@@ -104,11 +106,13 @@ pub struct CoreManagerBuilder {
     options: ManagerOptions,
     probes: ProbePlan,
     backend: Option<Arc<dyn RuntimeBackend>>,
+    dns: Option<Arc<dyn DnsController>>,
 }
 
 struct Inner {
     options: ManagerOptions,
     backend: Arc<dyn RuntimeBackend>,
+    dns: Option<Arc<dyn DnsController>>,
     store: RuntimeConfigStore,
     ctrl: tokio::sync::Mutex<Ctrl>,
     status_tx: watch::Sender<CoreStatus>,
@@ -135,6 +139,9 @@ struct Ctrl {
     current: Option<Active>,
     last_spec: Option<InstanceSpec>,
     quarantine: Vec<QuarantinedEpoch>,
+    /// The persisted-and-live DNS override, when a controller is injected and
+    /// an override is in place. Serialized by the control lock like the rest.
+    dns_record: Option<DnsOverrideRecord>,
 }
 
 #[derive(Debug, Clone)]
@@ -210,6 +217,13 @@ impl CoreManagerBuilder {
         self
     }
 
+    /// Injects the host DNS override component (amendment A5 ③). Without one
+    /// the manager has zero DNS behavior.
+    pub fn dns_controller(mut self, dns: Arc<dyn DnsController>) -> Self {
+        self.dns = Some(dns);
+        self
+    }
+
     pub async fn build(self) -> Result<CoreManager, Error> {
         CoreManager::build_configured(self).await
     }
@@ -221,6 +235,7 @@ impl CoreManager {
             options,
             probes: ProbePlan::default(),
             backend: None,
+            dns: None,
         }
     }
 
@@ -233,6 +248,7 @@ impl CoreManager {
             options,
             probes,
             backend,
+            dns,
         } = builder;
         let runtime_dir = options
             .runtime_dir
@@ -271,6 +287,7 @@ impl CoreManager {
             ));
         }
         let max_epoch = sweep_orphans(&store).await?;
+        dns_sync::reconcile_orphan_record(&store, dns.as_deref()).await;
         let (status_tx, _) = watch::channel(CoreStatus::initial());
         let (log_tx, _) = broadcast::channel(LOG_CHANNEL_CAPACITY);
         // Subscribed here rather than inside the task, and before any instance
@@ -301,6 +318,7 @@ impl CoreManager {
             inner: Arc::new(Inner {
                 options,
                 backend,
+                dns,
                 store,
                 ctrl: tokio::sync::Mutex::default(),
                 status_tx,
@@ -462,6 +480,9 @@ impl CoreManager {
     /// the number of possibly live processes; it does not clear quarantine.
     pub async fn stop(&self) -> Result<(), Error> {
         let mut ctrl = self.inner.ctrl.lock().await;
+        // Restore at the head of the stop transaction: resolution must never
+        // point at a core that is being torn down.
+        self.dns_restore(&mut ctrl).await;
         let Some(active) = ctrl.current.take() else {
             return Err(Error::NotStarted);
         };
@@ -567,6 +588,8 @@ impl CoreManager {
         // Held through sink finalization so no control-plane operation can interleave
         // between core stop and archive teardown.
         let mut ctrl = self.inner.ctrl.lock().await;
+        // Same head restore as `stop`.
+        self.dns_restore(&mut ctrl).await;
         let result: Result<(), Error> = async {
             if let Some(active) = ctrl.current.take() {
                 let Active {

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -4,6 +4,7 @@
 mod apply;
 mod publish;
 mod quarantine;
+mod reconcile;
 mod switching;
 
 use std::sync::{
@@ -59,6 +60,12 @@ pub enum SwitchOutcome {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ApplyOutcome {
+    /// Nothing was running; the desired runtime was started cold. Only
+    /// [`CoreManager::reconcile`] produces this — the legacy `apply_config`
+    /// path requires a running core.
+    Started {
+        revision: ConfigRevision,
+    },
     Noop {
         revision: ConfigRevision,
     },

--- a/crates/nyanpasu-core-manager/src/manager/publish.rs
+++ b/crates/nyanpasu-core-manager/src/manager/publish.rs
@@ -1,7 +1,7 @@
 use crate::{
     Feature, RuntimeFeature,
     error::Error,
-    instance::Instance,
+    runtime::RuntimeInstance,
     spec::InstanceSpec,
     state::{
         ConfigRevision, CoreState, CoreStatus, HealthStatus, InstanceState, InstanceStatus,
@@ -35,7 +35,7 @@ impl Inner {
 
     pub(super) fn publish_active(&self, active: &Active, state: CoreState) {
         self.publish_instance(
-            &active.instance,
+            active.instance.as_ref(),
             state,
             &active.source_spec,
             &active.revision,
@@ -46,7 +46,7 @@ impl Inner {
 
     pub(super) fn publish_instance(
         &self,
-        instance: &Instance,
+        instance: &dyn RuntimeInstance,
         state: CoreState,
         source_spec: &InstanceSpec,
         revision: &ConfigRevision,

--- a/crates/nyanpasu-core-manager/src/manager/quarantine.rs
+++ b/crates/nyanpasu-core-manager/src/manager/quarantine.rs
@@ -81,6 +81,9 @@ impl CoreManager {
         }
         self.inner
             .publish(CoreState::Stopped { reason: None }, None, None, None);
+        // Every uncertain epoch is now proven dead; nothing may keep holding
+        // the DNS override.
+        self.dns_restore(&mut ctrl).await;
         Ok(())
     }
 }

--- a/crates/nyanpasu-core-manager/src/manager/reconcile.rs
+++ b/crates/nyanpasu-core-manager/src/manager/reconcile.rs
@@ -1,0 +1,82 @@
+//! The unified mutating convergence entry (amendment A2): one command that
+//! makes the runtime match the desired spec. Start, patch, reload, restart,
+//! and switch are classifications this transaction derives — never caller
+//! choices — and the config check runs inside it, before any commit point.
+
+use crate::{error::Error, spec::InstanceSpec, state::RevisionId};
+
+use super::{ApplyOutcome, CoreManager, abort_and_await, quarantine::reject_quarantine};
+
+impl CoreManager {
+    /// Converges the runtime toward `spec`.
+    ///
+    /// Transaction envelope, mapped to the ten phases of the 2026-08-12
+    /// amendment A3 (admission by queue and idempotency live one layer up, in
+    /// the control executor):
+    ///
+    /// 1. admission — the quarantine gate rejects everything until recovery;
+    /// 2. CAS — `expected_applied` must name the actually applied revision
+    ///    (`None` claims nothing is applied; a mismatch changes nothing);
+    /// 3. internal check — parse ([`Error::InvalidConfig`]) and core dry run
+    ///    ([`Error::ConfigCheckFailed`]) inside the prepare step, before any
+    ///    commit point: a rejection is a clean abort with the previous runtime
+    ///    untouched;
+    /// 4. stage / classify / execute / verify / fallback / publish — the
+    ///    existing apply, switch, and start transactions, every stop proven
+    ///    by [`stop_and_confirm_dead`](crate::runtime::RuntimeInstance) or the
+    ///    manager latches quarantine.
+    ///
+    /// [`ApplyOutcome::RolledBack`] is a *successfully completed* transaction
+    /// whose desired config did not take effect; the actual revision rides in
+    /// the outcome.
+    pub async fn reconcile(
+        &self,
+        spec: InstanceSpec,
+        expected_applied: Option<RevisionId>,
+    ) -> Result<ApplyOutcome, Error> {
+        let mut ctrl = self.inner.ctrl.lock().await;
+        reject_quarantine(&ctrl)?;
+        let running = ctrl
+            .current
+            .as_ref()
+            .is_some_and(|active| !active.instance.state().borrow().state.is_terminal());
+        if running {
+            return self.apply_locked(&mut ctrl, spec, expected_applied).await;
+        }
+
+        // Nothing is effectively applied — a crashed epoch's revision is not
+        // an applied revision. A caller that believes one is applied must
+        // learn the truth before anything happens.
+        if let Some(expected) = expected_applied {
+            return Err(Error::RevisionConflict {
+                expected,
+                actual: None,
+            });
+        }
+
+        // Same stale-epoch hygiene as `start`: prove death before reuse.
+        if let Some(stale) = ctrl.current.take() {
+            abort_and_await(stale.forwarder).await;
+            let epoch = stale.instance.epoch();
+            if let Err(error) = stale
+                .instance
+                .stop_and_confirm_dead(self.inner.options.stop_timeout)
+                .await
+            {
+                if matches!(error, Error::StopUnconfirmed(_)) {
+                    return Err(self.latch_quarantine(&mut ctrl, epoch, error));
+                }
+                return Err(error);
+            }
+            self.inner.store.cleanup_epoch(epoch).await?;
+        }
+        self.start_locked(&mut ctrl, spec).await?;
+        let revision = ctrl
+            .current
+            .as_ref()
+            .expect("start_locked installed the active runtime")
+            .revision
+            .clone();
+        Ok(ApplyOutcome::Started { revision })
+    }
+}

--- a/crates/nyanpasu-core-manager/src/manager/reconcile.rs
+++ b/crates/nyanpasu-core-manager/src/manager/reconcile.rs
@@ -41,7 +41,20 @@ impl CoreManager {
             .await;
         // DNS rides the same transaction (fixed converge tail): applied while
         // the desired runtime is up, restored when nothing survived.
-        self.dns_converge(&mut ctrl).await;
+        //
+        // A rejected transaction is the exception, and only when it changed
+        // nothing: a CAS conflict or an invalid config leaves the previous
+        // runtime alive and untouched, so touching DNS would be a side effect
+        // of a refusal. A transaction that failed *and* left nothing running
+        // still converges, because that is the only place a restore can undo
+        // an override still pointing at a dead core.
+        let runtime_alive = ctrl
+            .current
+            .as_ref()
+            .is_some_and(|active| !active.instance.state().borrow().state.is_terminal());
+        if result.is_ok() || !runtime_alive {
+            self.dns_converge(&mut ctrl).await;
+        }
         result
     }
 

--- a/crates/nyanpasu-core-manager/src/manager/reconcile.rs
+++ b/crates/nyanpasu-core-manager/src/manager/reconcile.rs
@@ -36,12 +36,27 @@ impl CoreManager {
     ) -> Result<ApplyOutcome, Error> {
         let mut ctrl = self.inner.ctrl.lock().await;
         reject_quarantine(&ctrl)?;
+        let result = self
+            .reconcile_locked(&mut ctrl, spec, expected_applied)
+            .await;
+        // DNS rides the same transaction (fixed converge tail): applied while
+        // the desired runtime is up, restored when nothing survived.
+        self.dns_converge(&mut ctrl).await;
+        result
+    }
+
+    async fn reconcile_locked(
+        &self,
+        ctrl: &mut super::Ctrl,
+        spec: InstanceSpec,
+        expected_applied: Option<RevisionId>,
+    ) -> Result<ApplyOutcome, Error> {
         let running = ctrl
             .current
             .as_ref()
             .is_some_and(|active| !active.instance.state().borrow().state.is_terminal());
         if running {
-            return self.apply_locked(&mut ctrl, spec, expected_applied).await;
+            return self.apply_locked(ctrl, spec, expected_applied).await;
         }
 
         // Nothing is effectively applied — a crashed epoch's revision is not
@@ -64,13 +79,13 @@ impl CoreManager {
                 .await
             {
                 if matches!(error, Error::StopUnconfirmed(_)) {
-                    return Err(self.latch_quarantine(&mut ctrl, epoch, error));
+                    return Err(self.latch_quarantine(ctrl, epoch, error));
                 }
                 return Err(error);
             }
             self.inner.store.cleanup_epoch(epoch).await?;
         }
-        self.start_locked(&mut ctrl, spec).await?;
+        self.start_locked(ctrl, spec).await?;
         let revision = ctrl
             .current
             .as_ref()

--- a/crates/nyanpasu-core-manager/src/manager/switching.rs
+++ b/crates/nyanpasu-core-manager/src/manager/switching.rs
@@ -6,9 +6,9 @@ use crate::{
         mihomo::{self, OverlapBlock},
     },
     error::Error,
-    instance::Instance,
     kind::CoreKind,
     probe::ProbePhase,
+    runtime::RuntimeInstance,
     spec::{InstanceSpec, ResolvedController},
     state::{ConfigRevision, CoreState},
 };
@@ -299,7 +299,8 @@ impl CoreManager {
         let reconciled = tokio::time::timeout(self.inner.options.reconcile_timeout, async {
             match restoration.as_ref() {
                 Some((patch, projection)) => {
-                    self.patch_and_verify(&instance, patch, projection).await
+                    self.patch_and_verify(instance.as_ref(), patch, projection)
+                        .await
                 }
                 None => instance.probe_now(ProbePhase::Reconcile).await.is_healthy(),
             }
@@ -358,11 +359,16 @@ impl CoreManager {
         with_switch_durability_result(result, durability_warning)
     }
 
-    fn install_switched(&self, ctrl: &mut Ctrl, instance: Instance, prepared: PreparedLaunch) {
+    fn install_switched(
+        &self,
+        ctrl: &mut Ctrl,
+        instance: Box<dyn RuntimeInstance>,
+        prepared: PreparedLaunch,
+    ) {
         let epoch = prepared.revision.epoch;
         let pid = instance.pid().unwrap_or_default();
         self.inner.publish_instance(
-            &instance,
+            instance.as_ref(),
             CoreState::Running { epoch, pid },
             &prepared.source_spec,
             &prepared.revision,
@@ -428,7 +434,7 @@ impl CoreManager {
 
         let mut check_spec = spec.clone();
         check_spec.config_path = staged.path().to_owned();
-        crate::kind::check_config(&check_spec).await?;
+        self.inner.backend.check_config(&check_spec).await?;
 
         let runtime_path = self.inner.store.commit_new(staged, epoch).await?;
         let mut effective_spec = spec.clone();
@@ -489,11 +495,11 @@ impl CoreManager {
         let full_staged = self.inner.store.stage(epoch, &full.bytes).await?;
         let mut check_spec = spec.clone();
         check_spec.config_path = full_staged.path().to_owned();
-        crate::kind::check_config(&check_spec).await?;
+        self.inner.backend.check_config(&check_spec).await?;
 
         let bootstrap_staged = self.inner.store.stage(epoch, &bootstrap.bytes).await?;
         check_spec.config_path = bootstrap_staged.path().to_owned();
-        crate::kind::check_config(&check_spec).await?;
+        self.inner.backend.check_config(&check_spec).await?;
         let runtime_path = self.inner.store.commit_new(bootstrap_staged, epoch).await?;
 
         let mut effective_spec = spec.clone();
@@ -526,7 +532,7 @@ impl CoreManager {
         effective_spec: InstanceSpec,
         epoch: u64,
         controller: ResolvedController,
-    ) -> Result<Instance, Error> {
+    ) -> Result<Box<dyn RuntimeInstance>, Error> {
         let instance = self
             .spawn_instance(effective_spec, epoch, controller)
             .await?;

--- a/crates/nyanpasu-core-manager/src/runtime/mod.rs
+++ b/crates/nyanpasu-core-manager/src/runtime/mod.rs
@@ -1,0 +1,80 @@
+//! The runtime-backend boundary: how the orchestrator launches, observes, and
+//! provably stops a core runtime without naming the execution mechanism.
+//!
+//! Design §12 (first phase): one aggregated backend trait, no separate
+//! `CoreDriver` split, and no requirement that the orchestrator itself be
+//! backend-agnostic yet — `InstanceSpec` still carries process-shaped fields.
+//! The boundary exists so the control plane can be exercised against a fake
+//! runtime, and so the process mechanics have one front door.
+
+pub(crate) mod process;
+
+use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
+
+use tokio::sync::{broadcast, watch};
+
+use crate::{
+    error::Error,
+    log::LogFrame,
+    probe::{ProbePhase, ProbeResult},
+    spec::{InstanceSpec, ResolvedController},
+    state::InstanceStatus,
+};
+
+/// Manually boxed futures keep both traits dyn-compatible; native async trait
+/// methods are not.
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// One live core runtime owned by the orchestrator. Every method mirrors the
+/// surface the orchestrator actually consumes; nothing here promises a PID or
+/// a process — `pid` is `None` for runtimes that have none.
+pub trait RuntimeInstance: Send + Sync {
+    fn epoch(&self) -> u64;
+
+    fn spec(&self) -> &InstanceSpec;
+
+    fn controller(&self) -> &ResolvedController;
+
+    fn pid(&self) -> Option<u32>;
+
+    /// Live status feed; the orchestrator forwards it into the published
+    /// `CoreStatus`.
+    fn state(&self) -> watch::Receiver<InstanceStatus>;
+
+    /// Resolves when the readiness threshold is reached, or with the launch
+    /// failure.
+    fn wait_ready<'a>(&'a self) -> BoxFuture<'a, Result<(), Error>>;
+
+    /// One immediate health probe outside the periodic schedule.
+    fn probe_now<'a>(&'a self, phase: ProbePhase) -> BoxFuture<'a, ProbeResult>;
+
+    /// Stop and *prove* death within `timeout`. `Err(StopUnconfirmed)` is the
+    /// only honest answer when proof is unavailable, and the caller must
+    /// quarantine — a timeout is never "probably stopped" (design §7.4).
+    fn stop_and_confirm_dead(
+        self: Box<Self>,
+        timeout: Duration,
+    ) -> BoxFuture<'static, Result<(), Error>>;
+}
+
+/// Everything a launch needs beyond the backend's own construction-time
+/// dependencies. `log_tx` is the manager-owned broadcast channel that outlives
+/// every epoch.
+pub struct RuntimeLaunchRequest {
+    pub effective_spec: InstanceSpec,
+    pub epoch: u64,
+    pub controller: ResolvedController,
+    pub log_tx: broadcast::Sender<Arc<LogFrame>>,
+}
+
+/// Launches runtimes and validates configs for one execution mechanism.
+pub trait RuntimeBackend: Send + Sync {
+    fn launch(
+        &self,
+        request: RuntimeLaunchRequest,
+    ) -> BoxFuture<'_, Result<Box<dyn RuntimeInstance>, Error>>;
+
+    /// Dry-run validation of a staged config against the spec's core. Read
+    /// only; never touches the active runtime.
+    fn check_config<'a>(&'a self, spec: &'a InstanceSpec) -> BoxFuture<'a, Result<(), Error>>;
+}

--- a/crates/nyanpasu-core-manager/src/runtime/process.rs
+++ b/crates/nyanpasu-core-manager/src/runtime/process.rs
@@ -1,0 +1,111 @@
+//! The desktop execution mechanism: supervised child processes with PID-file
+//! death confirmation, fronted by the [`RuntimeBackend`] boundary.
+
+use std::time::Duration;
+
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    error::Error,
+    instance::Instance,
+    probe::{ProbeHandle, ProbePhase, ProbeResult},
+    spec::{InstanceSpec, ResolvedController},
+    state::InstanceStatus,
+};
+
+use super::{BoxFuture, RuntimeBackend, RuntimeInstance, RuntimeLaunchRequest};
+
+/// Probe wiring for instances the default backend launches. Collected by the
+/// manager builder; a custom backend owns its own probing instead.
+#[derive(Clone, Default)]
+pub(crate) struct ProbePlan {
+    pub(crate) readiness: Option<ProbeHandle>,
+    pub(crate) liveness: Option<ProbeHandle>,
+    pub(crate) liveness_with_readiness: bool,
+}
+
+pub(crate) struct ProcessRuntimeBackend {
+    probes: ProbePlan,
+    cancel_token: CancellationToken,
+}
+
+impl ProcessRuntimeBackend {
+    pub(crate) fn new(probes: ProbePlan, cancel_token: CancellationToken) -> Self {
+        Self {
+            probes,
+            cancel_token,
+        }
+    }
+}
+
+impl RuntimeBackend for ProcessRuntimeBackend {
+    fn launch(
+        &self,
+        request: RuntimeLaunchRequest,
+    ) -> BoxFuture<'_, Result<Box<dyn RuntimeInstance>, Error>> {
+        Box::pin(async move {
+            let RuntimeLaunchRequest {
+                effective_spec,
+                epoch,
+                controller,
+                log_tx,
+            } = request;
+            let mut builder =
+                Instance::builder(effective_spec, epoch, controller, self.cancel_token.clone())
+                    .log_sender(log_tx);
+            if let Some(probe) = self.probes.readiness.clone() {
+                builder = builder.readiness_probe(probe);
+            }
+            if let Some(probe) = self.probes.liveness.clone() {
+                builder = builder.liveness_probe(probe);
+            }
+            if self.probes.liveness_with_readiness {
+                builder = builder.liveness_with_readiness_probe();
+            }
+            let instance = builder.spawn().await?;
+            Ok(Box::new(instance) as Box<dyn RuntimeInstance>)
+        })
+    }
+
+    fn check_config<'a>(&'a self, spec: &'a InstanceSpec) -> BoxFuture<'a, Result<(), Error>> {
+        Box::pin(crate::kind::check_config(spec))
+    }
+}
+
+impl RuntimeInstance for Instance {
+    fn epoch(&self) -> u64 {
+        Instance::epoch(self)
+    }
+
+    fn spec(&self) -> &InstanceSpec {
+        Instance::spec(self)
+    }
+
+    fn controller(&self) -> &ResolvedController {
+        Instance::controller(self)
+    }
+
+    fn pid(&self) -> Option<u32> {
+        Instance::pid(self)
+    }
+
+    fn state(&self) -> watch::Receiver<InstanceStatus> {
+        Instance::state(self)
+    }
+
+    fn wait_ready<'a>(&'a self) -> BoxFuture<'a, Result<(), Error>> {
+        Box::pin(Instance::wait_ready(self))
+    }
+
+    fn probe_now<'a>(&'a self, phase: ProbePhase) -> BoxFuture<'a, ProbeResult> {
+        Box::pin(Instance::probe_now(self, phase))
+    }
+
+    fn stop_and_confirm_dead(
+        self: Box<Self>,
+        timeout: Duration,
+    ) -> BoxFuture<'static, Result<(), Error>> {
+        Box::pin(Instance::stop_and_confirm_dead(*self, timeout))
+    }
+}

--- a/crates/nyanpasu-core-manager/src/spec.rs
+++ b/crates/nyanpasu-core-manager/src/spec.rs
@@ -90,6 +90,11 @@ pub struct ManagerOptions {
     pub control_timeout: Duration,
     pub reconcile_timeout: Duration,
     pub stop_timeout: Duration,
+    /// Bound on one injected [`DnsController`](crate::dns::DnsController) call.
+    /// The converge tail runs under the control lock, so an unbounded platform
+    /// command would freeze every other transaction; a timeout is treated as
+    /// "the side effect is uncertain", never as "it did not happen".
+    pub dns_timeout: Duration,
     pub cancel_token: CancellationToken,
     /// Write core logs as JSONL under `{runtime_dir}/logs/`. Off means the
     /// directory is never created and nothing is written; an embedder with its
@@ -116,6 +121,7 @@ impl Default for ManagerOptions {
             control_timeout: Duration::from_secs(10),
             reconcile_timeout: Duration::from_secs(30),
             stop_timeout: Duration::from_secs(10),
+            dns_timeout: Duration::from_secs(10),
             cancel_token: CancellationToken::new(),
             log_sink_enabled: true,
             // 4 MiB x 5 = a 20 MiB ceiling — tighter than the service's own

--- a/crates/nyanpasu-core-manager/tests/control_plane.rs
+++ b/crates/nyanpasu-core-manager/tests/control_plane.rs
@@ -130,6 +130,8 @@ async fn an_idempotent_resubmit_attaches_to_the_original_operation() {
     let id = OperationId::generate();
     let first = control.submit(reconcile_envelope(id, &dir, &body)).unwrap();
     let second = control.submit(reconcile_envelope(id, &dir, &body)).unwrap();
+    assert!(first.newly_admitted(), "the first submit registers it");
+    assert!(!second.newly_admitted(), "the second attaches to it");
     let first = first.wait().await.unwrap();
     let second = second.wait().await.unwrap();
     // One operation, one start: both callers observe the identical outcome.
@@ -211,14 +213,28 @@ async fn a_full_queue_answers_queue_full() {
     let second = control
         .submit(reconcile_envelope(OperationId::generate(), &dir, &slow))
         .unwrap();
+    let rejected_id = OperationId::generate();
     let error = control
-        .submit(reconcile_envelope(OperationId::generate(), &dir, &slow))
+        .submit(reconcile_envelope(rejected_id, &dir, &slow))
         .unwrap_err();
     assert_eq!(error.kind, Some(CoreErrorKind::QueueFull));
     assert!(error.retryable);
+    // Admission is one critical section: a rejected enqueue leaves nothing
+    // behind for a concurrent caller to attach to, and the id stays reusable.
+    assert!(control.operation(rejected_id).is_none());
 
     first.wait().await.unwrap();
     let _ = second.wait().await;
+    control
+        .submit(reconcile_envelope(
+            rejected_id,
+            &dir,
+            &config_body(port, ""),
+        ))
+        .expect("a queue-full rejection keeps its id submittable")
+        .wait()
+        .await
+        .unwrap();
     control
         .submit(command_envelope(CoreCommand::Shutdown))
         .unwrap()
@@ -366,4 +382,124 @@ async fn a_declared_digest_mismatch_aborts_before_anything_happens() {
         .wait()
         .await
         .unwrap();
+}
+
+/// The declared digest is part of the operation's identity: correcting it
+/// describes a different claim, so re-using the id is a conflict rather than a
+/// replay of the first attempt's rejection.
+#[tokio::test]
+async fn a_corrected_declared_digest_conflicts_instead_of_attaching() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let control = control(&dir).await;
+    let spec = common::mihomo_spec(&dir, dir.join("unused.yaml"));
+    let bytes = config_body(port, "").into_bytes();
+    let id = OperationId::generate();
+    let envelope = |expected_digest: Option<String>| CoreCommandEnvelope {
+        operation_id: id,
+        command: CoreCommand::Reconcile(Box::new(ReconcileRequest {
+            core: spec.core.clone(),
+            config: ConfigInput::Inline {
+                bytes: bytes.clone(),
+                expected_digest,
+            },
+            options: spec.options.clone(),
+            expected_applied: None,
+        })),
+    };
+
+    let error = control
+        .submit(envelope(Some("0000000000000000".to_owned())))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::InvalidConfig));
+
+    let error = control
+        .submit(envelope(Some(nyanpasu_core_manager::payload_digest(
+            &bytes,
+        ))))
+        .unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::OperationConflict));
+
+    control
+        .submit(command_envelope(CoreCommand::Shutdown))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+}
+
+/// Two concurrent checks of the same bytes must not share one source file:
+/// the first to finish would delete the config the other is still using.
+#[tokio::test]
+async fn same_digest_checks_use_distinct_source_files() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let control = control(&dir).await;
+    let spec = common::mihomo_spec(&dir, dir.join("unused.yaml"));
+    let started = dir.join("check-started");
+    let body = config_body(
+        port,
+        &format!("x-fake-core:\n  check-delay-ms: 1500\n  check-started-file: '{started}'\n"),
+    );
+    let request = || CheckRequest {
+        core: spec.core.clone(),
+        config: ConfigInput::inline(body.clone().into_bytes()),
+    };
+    let sources = dir.join("sources");
+    let source_count = || {
+        std::fs::read_dir(&sources)
+            .map(|entries| {
+                entries
+                    .filter_map(Result::ok)
+                    .filter(|entry| {
+                        entry
+                            .file_name()
+                            .to_string_lossy()
+                            .starts_with("check-source")
+                    })
+                    .count()
+            })
+            .unwrap_or(0)
+    };
+
+    let first = tokio::spawn({
+        let control = control.clone();
+        let request = request();
+        async move { control.check(request).await }
+    });
+    wait_until(|| started.exists(), "the first check to reach its core").await;
+    let second = tokio::spawn({
+        let control = control.clone();
+        let request = request();
+        async move { control.check(request).await }
+    });
+    wait_until(
+        || source_count() == 2,
+        "both checks to own a distinct source file",
+    )
+    .await;
+
+    first.await.unwrap().expect("the first check completes");
+    second.await.unwrap().expect("the second check completes");
+    assert_eq!(source_count(), 0, "each check removes its own source file");
+
+    control
+        .submit(command_envelope(CoreCommand::Shutdown))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+}
+
+async fn wait_until(mut condition: impl FnMut() -> bool, what: &str) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while !condition() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {what}"));
 }

--- a/crates/nyanpasu-core-manager/tests/control_plane.rs
+++ b/crates/nyanpasu-core-manager/tests/control_plane.rs
@@ -503,3 +503,58 @@ async fn wait_until(mut condition: impl FnMut() -> bool, what: &str) {
     .await
     .unwrap_or_else(|_| panic!("timed out waiting for {what}"));
 }
+
+/// The registry, not the caller, owns operation state. `watch::Sender::send`
+/// hands the value back as an error when nothing is subscribed and leaves the
+/// stored one untouched, so a fire-and-forget submit -- which is exactly what
+/// `POST /v2/core/submit` is -- would leave its operation `Queued` forever and
+/// every later poll would subscribe to a state that stopped advancing.
+#[tokio::test]
+async fn an_operation_whose_handle_was_dropped_still_reaches_a_terminal_state() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let control = control(&dir).await;
+
+    let handle = control
+        .submit(command_envelope(CoreCommand::Stop))
+        .expect("the stop is admitted");
+    let id = handle.id();
+    drop(handle);
+
+    wait_until(
+        || {
+            matches!(
+                control.operation(id),
+                Some(OperationState::Succeeded(_)) | Some(OperationState::Failed(_))
+            )
+        },
+        "the dropped operation to reach a terminal state",
+    )
+    .await;
+}
+
+/// The executor's drain rests on three properties of a tokio mpsc, and a
+/// change in any of them silently reopens the hole it closes: an operation
+/// admitted through a reserved permit would land in a queue nobody reads and
+/// never reach a terminal state.
+#[tokio::test]
+async fn a_closed_queue_still_delivers_an_outstanding_permit() {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<u8>(4);
+    let permit = tx.reserve().await.expect("the queue is open");
+    rx.close();
+
+    // 1. `try_recv` reports the queue empty while the permit is outstanding.
+    assert!(rx.try_recv().is_err());
+
+    // 2. `recv` waits for it rather than ending the drain early.
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+            .await
+            .is_err()
+    );
+
+    // 3. The permit still delivers into a closed queue, and only then does the
+    //    drain see the end.
+    permit.send(7);
+    assert_eq!(rx.recv().await, Some(7));
+    assert_eq!(rx.recv().await, None);
+}

--- a/crates/nyanpasu-core-manager/tests/control_plane.rs
+++ b/crates/nyanpasu-core-manager/tests/control_plane.rs
@@ -1,0 +1,369 @@
+//! Contract tests for the control plane: admission, idempotency, cancellation
+//! isolation, the closing latch, and the advisory check (audit §3.2 matrix,
+//! executor rows).
+
+mod common;
+
+use std::time::Duration;
+
+use camino::Utf8Path;
+use nyanpasu_core_manager::{
+    CheckRequest, ConfigInput, ControlOptions, CoreCommand, CoreCommandEnvelope, CoreControl,
+    CoreErrorKind, CoreState, ExecutorExit, ManagerOptions, OperationId, OperationOutput,
+    OperationState, ReconcileRequest,
+    manager::{ApplyOutcome, CoreManager},
+};
+
+fn config_body(port: u16, extra: &str) -> String {
+    format!("external-controller: 127.0.0.1:{port}\n{extra}")
+}
+
+async fn control_with(
+    dir: &Utf8Path,
+    tweak: impl FnOnce(ControlOptions) -> ControlOptions,
+) -> CoreControl {
+    let manager = CoreManager::new(ManagerOptions {
+        runtime_dir: Some(dir.join("runtime")),
+        ..ManagerOptions::default()
+    })
+    .await
+    .expect("construct manager");
+    let options = tweak(ControlOptions::new(dir.join("sources"), dir.to_owned()));
+    CoreControl::spawn(manager, options)
+}
+
+async fn control(dir: &Utf8Path) -> CoreControl {
+    control_with(dir, |options| options).await
+}
+
+fn reconcile_envelope(id: OperationId, dir: &Utf8Path, body: &str) -> CoreCommandEnvelope {
+    let spec = common::mihomo_spec(dir, dir.join("unused.yaml"));
+    CoreCommandEnvelope {
+        operation_id: id,
+        command: CoreCommand::Reconcile(Box::new(ReconcileRequest {
+            core: spec.core,
+            config: ConfigInput::inline(body.as_bytes().to_vec()),
+            options: spec.options,
+            expected_applied: None,
+        })),
+    }
+}
+
+fn command_envelope(command: CoreCommand) -> CoreCommandEnvelope {
+    CoreCommandEnvelope {
+        operation_id: OperationId::generate(),
+        command,
+    }
+}
+
+async fn wait_core_state(
+    control: &CoreControl,
+    pred: impl Fn(&CoreState) -> bool,
+    what: &str,
+) -> CoreState {
+    let mut rx = control.subscribe();
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let current = rx.borrow_and_update().state.clone();
+            if pred(&current) {
+                return current;
+            }
+            rx.changed().await.expect("status channel closed");
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {what}"))
+}
+
+#[tokio::test]
+async fn a_submitted_reconcile_runs_to_started_and_stop_completes() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let control = control(&dir).await;
+
+    let id = OperationId::generate();
+    let handle = control
+        .submit(reconcile_envelope(id, &dir, &config_body(port, "")))
+        .unwrap();
+    let output = handle.wait().await.unwrap();
+    let OperationOutput::Reconciled(ApplyOutcome::Started { .. }) = output else {
+        panic!("expected a cold start, got {output:?}");
+    };
+    assert!(matches!(control.status().state, CoreState::Running { .. }));
+    assert!(matches!(
+        control.operation(id),
+        Some(OperationState::Succeeded(_))
+    ));
+
+    let output = control
+        .submit(command_envelope(CoreCommand::Stop))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+    assert!(matches!(output, OperationOutput::Stopped));
+
+    // Stopping again fails with the manager's own classification.
+    let error = control
+        .submit(command_envelope(CoreCommand::Stop))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::NotStarted));
+
+    control
+        .submit(command_envelope(CoreCommand::Shutdown))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn an_idempotent_resubmit_attaches_to_the_original_operation() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let control = control(&dir).await;
+    let body = config_body(port, "");
+
+    let id = OperationId::generate();
+    let first = control.submit(reconcile_envelope(id, &dir, &body)).unwrap();
+    let second = control.submit(reconcile_envelope(id, &dir, &body)).unwrap();
+    let first = first.wait().await.unwrap();
+    let second = second.wait().await.unwrap();
+    // One operation, one start: both callers observe the identical outcome.
+    assert_eq!(first, second);
+    let OperationOutput::Reconciled(ApplyOutcome::Started { revision }) = first else {
+        panic!("expected a cold start, got {first:?}");
+    };
+    assert_eq!(
+        revision.epoch, 1,
+        "a second start would have bumped the epoch"
+    );
+
+    control
+        .submit(command_envelope(CoreCommand::Shutdown))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn an_id_reuse_with_a_different_payload_conflicts_at_submit() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let control = control(&dir).await;
+
+    let id = OperationId::generate();
+    let handle = control
+        .submit(reconcile_envelope(id, &dir, &config_body(port, "")))
+        .unwrap();
+    let error = control
+        .submit(reconcile_envelope(
+            id,
+            &dir,
+            &config_body(port, "mixed-port: 7899\n"),
+        ))
+        .unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::OperationConflict));
+    assert!(
+        !error.retryable,
+        "retrying the same conflict cannot succeed"
+    );
+
+    handle.wait().await.unwrap();
+    control
+        .submit(command_envelope(CoreCommand::Shutdown))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_full_queue_answers_queue_full() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let control = control_with(&dir, |mut options| {
+        options.queue_capacity = 1;
+        options
+    })
+    .await;
+    // The dry-run delay holds the executor busy long enough for the queue to
+    // fill deterministically.
+    let slow = config_body(port, "x-fake-core:\n  check-delay-ms: 1500\n");
+
+    let first_id = OperationId::generate();
+    let first = control
+        .submit(reconcile_envelope(first_id, &dir, &slow))
+        .unwrap();
+    // The queue slot frees only once the executor dequeues the first
+    // operation; wait for Running before filling the slot again.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !matches!(control.operation(first_id), Some(OperationState::Running)) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the first operation must start running");
+    let second = control
+        .submit(reconcile_envelope(OperationId::generate(), &dir, &slow))
+        .unwrap();
+    let error = control
+        .submit(reconcile_envelope(OperationId::generate(), &dir, &slow))
+        .unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::QueueFull));
+    assert!(error.retryable);
+
+    first.wait().await.unwrap();
+    let _ = second.wait().await;
+    control
+        .submit(command_envelope(CoreCommand::Shutdown))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn dropping_the_handle_never_cancels_the_transaction() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let control = control(&dir).await;
+
+    let handle = control
+        .submit(reconcile_envelope(
+            OperationId::generate(),
+            &dir,
+            &config_body(port, ""),
+        ))
+        .unwrap();
+    drop(handle);
+
+    // The transaction runs to its terminal state with nobody waiting.
+    wait_core_state(
+        &control,
+        |state| matches!(state, CoreState::Running { .. }),
+        "the abandoned reconcile to finish starting the core",
+    )
+    .await;
+
+    control
+        .submit(command_envelope(CoreCommand::Shutdown))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn shutdown_latches_admission_and_drains_cleanly() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let control = control(&dir).await;
+
+    let shutdown = control
+        .submit(command_envelope(CoreCommand::Shutdown))
+        .unwrap();
+    let error = control
+        .submit(reconcile_envelope(
+            OperationId::generate(),
+            &dir,
+            &config_body(port, ""),
+        ))
+        .unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::ShuttingDown));
+
+    let output = shutdown.wait().await.unwrap();
+    assert!(matches!(output, OperationOutput::ShutDown));
+    assert_eq!(control.until_closed().await, ExecutorExit::Clean);
+}
+
+#[tokio::test]
+async fn the_advisory_check_neither_queues_nor_disturbs_the_runtime() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let control = control(&dir).await;
+    let spec = common::mihomo_spec(&dir, dir.join("unused.yaml"));
+
+    let started = control
+        .submit(reconcile_envelope(
+            OperationId::generate(),
+            &dir,
+            &config_body(port, ""),
+        ))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+    let OperationOutput::Reconciled(ApplyOutcome::Started { revision }) = started else {
+        panic!("expected a cold start");
+    };
+
+    control
+        .check(CheckRequest {
+            core: spec.core.clone(),
+            config: ConfigInput::inline(config_body(port, "mixed-port: 7899\n").into_bytes()),
+        })
+        .await
+        .expect("a valid config passes the advisory check");
+
+    let error = control
+        .check(CheckRequest {
+            core: spec.core,
+            config: ConfigInput::inline(
+                config_body(port, "x-fake-core:\n  check-fail: port already in use\n").into_bytes(),
+            ),
+        })
+        .await
+        .expect_err("the core's dry-run rejection surfaces");
+    assert_eq!(error.kind, Some(CoreErrorKind::ConfigCheckFailed));
+
+    // Advisory means advisory: the runtime never moved.
+    let status = control.status();
+    assert!(matches!(status.state, CoreState::Running { .. }));
+    assert_eq!(
+        status.revision.as_ref().map(|revision| revision.id()),
+        Some(revision.id())
+    );
+
+    control
+        .submit(command_envelope(CoreCommand::Shutdown))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_declared_digest_mismatch_aborts_before_anything_happens() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let control = control(&dir).await;
+    let spec = common::mihomo_spec(&dir, dir.join("unused.yaml"));
+
+    let envelope = CoreCommandEnvelope {
+        operation_id: OperationId::generate(),
+        command: CoreCommand::Reconcile(Box::new(ReconcileRequest {
+            core: spec.core,
+            config: ConfigInput::Inline {
+                bytes: config_body(port, "").into_bytes(),
+                expected_digest: Some("0000000000000000".to_owned()),
+            },
+            options: spec.options,
+            expected_applied: None,
+        })),
+    };
+    let error = control.submit(envelope).unwrap().wait().await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::InvalidConfig));
+    assert!(matches!(control.status().state, CoreState::Stopped { .. }));
+
+    control
+        .submit(command_envelope(CoreCommand::Shutdown))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+}

--- a/crates/nyanpasu-core-manager/tests/dns_override.rs
+++ b/crates/nyanpasu-core-manager/tests/dns_override.rs
@@ -1,0 +1,204 @@
+//! DNS override wiring: fixed-phase converge/restore, the persisted record,
+//! orphan reconcile at construction, and the never-fail-the-transaction
+//! policy — all against a fake controller.
+
+mod common;
+
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+use nyanpasu_core_manager::{
+    CoreState, ManagerOptions,
+    dns::{DnsController, DnsError, DnsIntent, DnsOverrideRecord, DnsOverrideState},
+    manager::{ApplyOutcome, CoreManager},
+    runtime::BoxFuture,
+};
+
+#[derive(Default)]
+struct FakeDns {
+    applied: Mutex<Vec<(DnsIntent, u64)>>,
+    restored: Mutex<Vec<DnsOverrideRecord>>,
+    fail_apply: AtomicBool,
+}
+
+impl DnsController for FakeDns {
+    fn desired(&self, _effective: &serde_yaml_ng::Mapping) -> Option<DnsIntent> {
+        Some(DnsIntent {
+            servers: vec!["198.18.0.2".to_owned()],
+        })
+    }
+
+    fn apply<'a>(
+        &'a self,
+        intent: &'a DnsIntent,
+        runtime_epoch: u64,
+    ) -> BoxFuture<'a, Result<DnsOverrideRecord, DnsError>> {
+        Box::pin(async move {
+            if self.fail_apply.load(Ordering::SeqCst) {
+                return Err(DnsError::Command("injected apply failure".into()));
+            }
+            self.applied
+                .lock()
+                .unwrap()
+                .push((intent.clone(), runtime_epoch));
+            Ok(DnsOverrideRecord {
+                interface: "Wi-Fi".to_owned(),
+                previous: vec!["10.0.0.1".to_owned()],
+                applied: intent.servers.clone(),
+                runtime_epoch,
+                owner_generation: None,
+                state: DnsOverrideState::Applied,
+            })
+        })
+    }
+
+    fn restore<'a>(&'a self, record: &'a DnsOverrideRecord) -> BoxFuture<'a, Result<(), DnsError>> {
+        Box::pin(async move {
+            self.restored.lock().unwrap().push(record.clone());
+            Ok(())
+        })
+    }
+}
+
+async fn manager_with_dns(dir: &camino::Utf8Path, dns: Arc<FakeDns>) -> CoreManager {
+    CoreManager::builder(ManagerOptions {
+        runtime_dir: Some(dir.join("runtime")),
+        ..ManagerOptions::default()
+    })
+    .dns_controller(dns)
+    .build()
+    .await
+    .expect("construct manager")
+}
+
+fn record_path(dir: &camino::Utf8Path) -> camino::Utf8PathBuf {
+    dir.join("runtime").join("dns-override.json")
+}
+
+#[tokio::test]
+async fn reconcile_applies_the_override_and_stop_restores_it_first() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let spec = common::mihomo_spec(&dir, config);
+    let dns = Arc::new(FakeDns::default());
+    let manager = manager_with_dns(&dir, dns.clone()).await;
+
+    let outcome = manager.reconcile(spec.clone(), None).await.unwrap();
+    assert!(matches!(outcome, ApplyOutcome::Started { .. }));
+    {
+        let applied = dns.applied.lock().unwrap();
+        assert_eq!(applied.len(), 1, "start tail applies exactly once");
+        assert_eq!(applied[0].0.servers, vec!["198.18.0.2".to_owned()]);
+        assert_eq!(applied[0].1, 1, "the record names the running epoch");
+    }
+    // The record survived to disk with the controller's read-back data.
+    let record: DnsOverrideRecord =
+        serde_json::from_slice(&std::fs::read(record_path(&dir)).unwrap()).unwrap();
+    assert_eq!(record.state, DnsOverrideState::Applied);
+    assert_eq!(record.previous, vec!["10.0.0.1".to_owned()]);
+
+    manager.stop().await.unwrap();
+    {
+        let restored = dns.restored.lock().unwrap();
+        assert_eq!(restored.len(), 1, "stop head restores exactly once");
+        assert_eq!(restored[0].applied, vec!["198.18.0.2".to_owned()]);
+    }
+    assert!(
+        !record_path(&dir).exists(),
+        "a restored override leaves no record behind"
+    );
+
+    manager.shutdown().await.unwrap();
+    assert_eq!(
+        dns.restored.lock().unwrap().len(),
+        1,
+        "shutdown after a clean stop has nothing left to restore"
+    );
+}
+
+#[tokio::test]
+async fn a_noop_reconcile_reapplies_idempotently() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let spec = common::mihomo_spec(&dir, config);
+    let dns = Arc::new(FakeDns::default());
+    let manager = manager_with_dns(&dir, dns.clone()).await;
+
+    manager.reconcile(spec.clone(), None).await.unwrap();
+    let outcome = manager.reconcile(spec, None).await.unwrap();
+    assert!(matches!(outcome, ApplyOutcome::Noop { .. }));
+    // The converge tail runs each transaction; idempotency is the
+    // controller's contract, observed here as a second harmless apply.
+    assert_eq!(dns.applied.lock().unwrap().len(), 2);
+
+    manager.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn an_orphan_record_is_restored_at_construction() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let runtime_dir = dir.join("runtime");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    let orphan = DnsOverrideRecord {
+        interface: "Wi-Fi".to_owned(),
+        previous: vec!["10.0.0.1".to_owned()],
+        applied: vec!["198.18.0.2".to_owned()],
+        runtime_epoch: 7,
+        owner_generation: None,
+        state: DnsOverrideState::Applied,
+    };
+    std::fs::write(
+        runtime_dir.join("dns-override.json"),
+        serde_json::to_vec(&orphan).unwrap(),
+    )
+    .unwrap();
+
+    let dns = Arc::new(FakeDns::default());
+    let manager = manager_with_dns(&dir, dns.clone()).await;
+    {
+        let restored = dns.restored.lock().unwrap();
+        assert_eq!(restored.len(), 1, "construction reconciles the orphan");
+        assert_eq!(restored[0], orphan);
+    }
+    assert!(!record_path(&dir).exists());
+
+    manager.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn a_dns_apply_failure_never_fails_the_transaction() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let spec = common::mihomo_spec(&dir, config);
+    let dns = Arc::new(FakeDns::default());
+    dns.fail_apply.store(true, Ordering::SeqCst);
+    let manager = manager_with_dns(&dir, dns.clone()).await;
+
+    let outcome = manager.reconcile(spec, None).await.unwrap();
+    assert!(
+        matches!(outcome, ApplyOutcome::Started { .. }),
+        "the core transaction succeeds regardless of DNS"
+    );
+    assert!(matches!(manager.status().state, CoreState::Running { .. }));
+    // The pre-record is kept: the side effect is uncertain and a later
+    // restore must still be able to undo it.
+    let record: DnsOverrideRecord =
+        serde_json::from_slice(&std::fs::read(record_path(&dir)).unwrap()).unwrap();
+    assert!(
+        record.previous.is_empty(),
+        "a pre-record has no read-back yet"
+    );
+
+    manager.shutdown().await.unwrap();
+    assert_eq!(
+        dns.restored.lock().unwrap().len(),
+        1,
+        "shutdown restores the uncertain pre-record"
+    );
+    assert!(!record_path(&dir).exists());
+}

--- a/crates/nyanpasu-core-manager/tests/dns_override.rs
+++ b/crates/nyanpasu-core-manager/tests/dns_override.rs
@@ -4,23 +4,52 @@
 
 mod common;
 
-use std::sync::{
-    Arc, Mutex,
-    atomic::{AtomicBool, Ordering},
+use std::{
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
 };
 
 use nyanpasu_core_manager::{
-    CoreState, ManagerOptions,
+    CoreState, Error, ManagerOptions, RevisionId,
     dns::{DnsController, DnsError, DnsIntent, DnsOverrideRecord, DnsOverrideState},
     manager::{ApplyOutcome, CoreManager},
     runtime::BoxFuture,
 };
+use tokio::sync::Notify;
 
-#[derive(Default)]
+/// Stateful on purpose: `previous` has to be something the controller
+/// *observed*, not a constant the fake hands back. A fake that always answers
+/// with the original resolver would prove the baseline was kept even when the
+/// orchestrator overwrote it.
 struct FakeDns {
     applied: Mutex<Vec<(DnsIntent, u64)>>,
     restored: Mutex<Vec<DnsOverrideRecord>>,
+    /// What the interface currently resolves through.
+    current: Mutex<Vec<String>>,
     fail_apply: AtomicBool,
+    fail_restore: AtomicBool,
+    hang_apply: AtomicBool,
+    hang_restore: AtomicBool,
+    /// Never notified: a call that waits on it never returns.
+    never: Notify,
+}
+
+impl Default for FakeDns {
+    fn default() -> Self {
+        Self {
+            applied: Mutex::new(Vec::new()),
+            restored: Mutex::new(Vec::new()),
+            current: Mutex::new(vec!["10.0.0.1".to_owned()]),
+            fail_apply: AtomicBool::new(false),
+            fail_restore: AtomicBool::new(false),
+            hang_apply: AtomicBool::new(false),
+            hang_restore: AtomicBool::new(false),
+            never: Notify::new(),
+        }
+    }
 }
 
 impl DnsController for FakeDns {
@@ -36,16 +65,21 @@ impl DnsController for FakeDns {
         runtime_epoch: u64,
     ) -> BoxFuture<'a, Result<DnsOverrideRecord, DnsError>> {
         Box::pin(async move {
+            if self.hang_apply.load(Ordering::SeqCst) {
+                self.never.notified().await;
+            }
             if self.fail_apply.load(Ordering::SeqCst) {
                 return Err(DnsError::Command("injected apply failure".into()));
             }
+            let previous =
+                std::mem::replace(&mut *self.current.lock().unwrap(), intent.servers.clone());
             self.applied
                 .lock()
                 .unwrap()
                 .push((intent.clone(), runtime_epoch));
             Ok(DnsOverrideRecord {
                 interface: "Wi-Fi".to_owned(),
-                previous: vec!["10.0.0.1".to_owned()],
+                previous,
                 applied: intent.servers.clone(),
                 runtime_epoch,
                 owner_generation: None,
@@ -56,7 +90,14 @@ impl DnsController for FakeDns {
 
     fn restore<'a>(&'a self, record: &'a DnsOverrideRecord) -> BoxFuture<'a, Result<(), DnsError>> {
         Box::pin(async move {
+            if self.hang_restore.load(Ordering::SeqCst) {
+                self.never.notified().await;
+            }
+            if self.fail_restore.load(Ordering::SeqCst) {
+                return Err(DnsError::Command("injected restore failure".into()));
+            }
             self.restored.lock().unwrap().push(record.clone());
+            *self.current.lock().unwrap() = record.previous.clone();
             Ok(())
         })
     }
@@ -65,6 +106,22 @@ impl DnsController for FakeDns {
 async fn manager_with_dns(dir: &camino::Utf8Path, dns: Arc<FakeDns>) -> CoreManager {
     CoreManager::builder(ManagerOptions {
         runtime_dir: Some(dir.join("runtime")),
+        ..ManagerOptions::default()
+    })
+    .dns_controller(dns)
+    .build()
+    .await
+    .expect("construct manager")
+}
+
+async fn manager_with_dns_timeout(
+    dir: &camino::Utf8Path,
+    dns: Arc<FakeDns>,
+    dns_timeout: Duration,
+) -> CoreManager {
+    CoreManager::builder(ManagerOptions {
+        runtime_dir: Some(dir.join("runtime")),
+        dns_timeout,
         ..ManagerOptions::default()
     })
     .dns_controller(dns)
@@ -134,8 +191,13 @@ async fn a_noop_reconcile_reapplies_idempotently() {
     // The converge tail runs each transaction; idempotency is the
     // controller's contract, observed here as a second harmless apply.
     assert_eq!(dns.applied.lock().unwrap().len(), 2);
+    // ...and the baseline the first one captured is still the one on record.
+    let record: DnsOverrideRecord =
+        serde_json::from_slice(&std::fs::read(record_path(&dir)).unwrap()).unwrap();
+    assert_eq!(record.previous, vec!["10.0.0.1".to_owned()]);
 
     manager.shutdown().await.unwrap();
+    assert_eq!(*dns.current.lock().unwrap(), vec!["10.0.0.1".to_owned()]);
 }
 
 #[tokio::test]
@@ -201,4 +263,321 @@ async fn a_dns_apply_failure_never_fails_the_transaction() {
         "shutdown restores the uncertain pre-record"
     );
     assert!(!record_path(&dir).exists());
+}
+
+/// Record before side effect is a crash-recovery guarantee, so the apply
+/// direction is fail-closed: an override nothing recorded is an override
+/// nothing can undo. The core transaction is unaffected either way.
+#[tokio::test]
+async fn an_unwritable_record_blocks_the_override_but_not_the_transaction() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let spec = common::mihomo_spec(&dir, config);
+    let dns = Arc::new(FakeDns::default());
+    let manager = manager_with_dns(&dir, dns.clone()).await;
+    // A directory where the record belongs: the publish cannot succeed.
+    std::fs::create_dir(record_path(&dir)).unwrap();
+
+    let outcome = manager.reconcile(spec, None).await.unwrap();
+    assert!(
+        matches!(outcome, ApplyOutcome::Started { .. }),
+        "the core transaction succeeds regardless of DNS"
+    );
+    assert!(matches!(manager.status().state, CoreState::Running { .. }));
+    assert!(
+        dns.applied.lock().unwrap().is_empty(),
+        "no record, no side effect"
+    );
+    assert_eq!(*dns.current.lock().unwrap(), vec!["10.0.0.1".to_owned()]);
+
+    manager.shutdown().await.unwrap();
+}
+
+/// The write is atomic, so a crash cannot leave a half-written record that
+/// parses as nothing and undoes nothing.
+#[tokio::test]
+async fn the_published_record_parses_and_leaves_no_staging_file() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let spec = common::mihomo_spec(&dir, config);
+    let dns = Arc::new(FakeDns::default());
+    let manager = manager_with_dns(&dir, dns).await;
+
+    manager.reconcile(spec, None).await.unwrap();
+    serde_json::from_slice::<DnsOverrideRecord>(&std::fs::read(record_path(&dir)).unwrap())
+        .expect("the published record parses");
+    assert!(
+        !dir.join("runtime").join("dns-override.json.tmp").exists(),
+        "the staging file is consumed by the replace"
+    );
+
+    manager.shutdown().await.unwrap();
+}
+
+/// The baseline is whatever resolution looked like *before* this process took
+/// over. Re-reading it on every converge would record our own override as the
+/// thing to restore to, and the original resolver would be lost after the
+/// second transaction.
+#[tokio::test]
+async fn a_second_converge_keeps_the_original_previous() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let spec = common::mihomo_spec(&dir, config);
+    let dns = Arc::new(FakeDns::default());
+    let manager = manager_with_dns(&dir, dns.clone()).await;
+
+    manager.reconcile(spec.clone(), None).await.unwrap();
+    manager.reconcile(spec, None).await.unwrap();
+    let record: DnsOverrideRecord =
+        serde_json::from_slice(&std::fs::read(record_path(&dir)).unwrap()).unwrap();
+    assert_eq!(record.previous, vec!["10.0.0.1".to_owned()]);
+
+    manager.stop().await.unwrap();
+    assert_eq!(
+        *dns.current.lock().unwrap(),
+        vec!["10.0.0.1".to_owned()],
+        "the interface is handed back to the resolver it started with"
+    );
+
+    manager.shutdown().await.unwrap();
+}
+
+/// The converge tail runs under the control lock. An unbounded platform
+/// command there freezes every other transaction, so each call is bounded and
+/// a timeout is treated as an uncertain side effect.
+#[tokio::test]
+async fn a_hung_dns_apply_cannot_freeze_the_control_plane() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let spec = common::mihomo_spec(&dir, config);
+    let dns = Arc::new(FakeDns::default());
+    dns.hang_apply.store(true, Ordering::SeqCst);
+    let manager = manager_with_dns_timeout(&dir, dns.clone(), Duration::from_millis(200)).await;
+
+    manager.reconcile(spec, None).await.unwrap();
+    // The pre-record survives: the side effect may or may not have landed.
+    let record: DnsOverrideRecord =
+        serde_json::from_slice(&std::fs::read(record_path(&dir)).unwrap()).unwrap();
+    assert_eq!(record.state, DnsOverrideState::Applied);
+
+    dns.hang_apply.store(false, Ordering::SeqCst);
+    manager.stop().await.unwrap();
+    manager.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn a_hung_dns_restore_is_bounded() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let spec = common::mihomo_spec(&dir, config);
+    let dns = Arc::new(FakeDns::default());
+    let manager = manager_with_dns_timeout(&dir, dns.clone(), Duration::from_millis(200)).await;
+    manager.reconcile(spec, None).await.unwrap();
+
+    dns.hang_restore.store(true, Ordering::SeqCst);
+    manager.stop().await.unwrap();
+    let record: DnsOverrideRecord =
+        serde_json::from_slice(&std::fs::read(record_path(&dir)).unwrap()).unwrap();
+    assert_eq!(
+        record.state,
+        DnsOverrideState::RestorePending,
+        "an unfinished restore stays on record for the next attempt"
+    );
+}
+
+/// The orphan reconcile runs inside manager construction, before anything can
+/// serve. It is bounded for the same reason the converge tail is.
+#[tokio::test]
+async fn a_hung_orphan_restore_does_not_block_construction() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let runtime_dir = dir.join("runtime");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    let orphan = DnsOverrideRecord {
+        interface: "Wi-Fi".to_owned(),
+        previous: vec!["10.0.0.1".to_owned()],
+        applied: vec!["198.18.0.2".to_owned()],
+        runtime_epoch: 7,
+        owner_generation: None,
+        state: DnsOverrideState::Applied,
+    };
+    std::fs::write(record_path(&dir), serde_json::to_vec(&orphan).unwrap()).unwrap();
+    let dns = Arc::new(FakeDns::default());
+    dns.hang_restore.store(true, Ordering::SeqCst);
+
+    let manager = manager_with_dns_timeout(&dir, dns, Duration::from_millis(200)).await;
+    assert!(
+        record_path(&dir).exists(),
+        "an unfinished orphan restore keeps its record"
+    );
+
+    manager.shutdown().await.unwrap();
+}
+
+/// A clean abort changed nothing, so it must have no DNS side effect at all.
+#[tokio::test]
+async fn a_revision_conflict_never_touches_dns() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let spec = common::mihomo_spec(&dir, config);
+    let dns = Arc::new(FakeDns::default());
+    let manager = manager_with_dns(&dir, dns.clone()).await;
+    manager.reconcile(spec.clone(), None).await.unwrap();
+    let before = std::fs::read(record_path(&dir)).unwrap();
+
+    let stale = RevisionId {
+        epoch: 99,
+        generation: 99,
+        effective_hash: "deadbeef".to_owned(),
+    };
+    let error = manager.reconcile(spec, Some(stale)).await.unwrap_err();
+    assert!(matches!(error, Error::RevisionConflict { .. }));
+    assert_eq!(
+        dns.applied.lock().unwrap().len(),
+        1,
+        "a refused transaction re-applies nothing"
+    );
+    assert_eq!(std::fs::read(record_path(&dir)).unwrap(), before);
+
+    manager.shutdown().await.unwrap();
+}
+
+/// The other half of the same rule. A transaction that failed *and* left
+/// nothing running is exactly where an override outlives the core it was
+/// applied for, so the converge tail still runs and restores it. Skipping DNS
+/// on every `Err` would leave the system resolving through a dead core until
+/// the next successful operation.
+#[tokio::test]
+async fn a_failed_transaction_that_leaves_nothing_running_restores_dns() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let counter = dir.join("launch-count.txt").as_str().replace('\\', "/");
+    let behavior =
+        format!("x-fake-core:\n  launch-count-file: '{counter}'\n  fail-after-launches: 1\n");
+    let first = dir.join("first.yaml");
+    std::fs::write(
+        &first,
+        format!("external-controller: 127.0.0.1:{port}\nx-setting: old\n{behavior}"),
+    )
+    .unwrap();
+    let desired = dir.join("desired.yaml");
+    std::fs::write(
+        &desired,
+        format!(
+            "external-controller: 127.0.0.1:{port}\nx-setting: desired\n{behavior}  exit-code: 23\n"
+        ),
+    )
+    .unwrap();
+
+    let dns = Arc::new(FakeDns::default());
+    let manager = manager_with_dns(&dir, dns.clone()).await;
+    manager
+        .reconcile(common::mihomo_spec(&dir, first), None)
+        .await
+        .expect("the first start succeeds");
+    assert_eq!(dns.applied.lock().unwrap().len(), 1);
+
+    // Both the apply and its rollback fail to launch, so no runtime survives.
+    manager
+        .reconcile(common::mihomo_spec(&dir, desired), None)
+        .await
+        .expect_err("both launch attempts fail");
+    assert!(matches!(manager.status().state, CoreState::Stopped { .. }));
+
+    assert_eq!(
+        dns.restored.lock().unwrap().len(),
+        1,
+        "the override must not outlive the core it was applied for"
+    );
+    assert_eq!(*dns.current.lock().unwrap(), vec!["10.0.0.1".to_owned()]);
+    assert!(!record_path(&dir).exists());
+
+    manager.shutdown().await.unwrap();
+}
+
+/// A restore that did not succeed leaves the record `RestorePending` and the
+/// override still in place. That record is still this process's proof of what
+/// resolution looked like before it took over -- treating it as "no baseline"
+/// makes the next converge read our own override back as `previous`, and the
+/// restore after that pins the host at the core's resolver forever.
+#[tokio::test]
+async fn a_restore_pending_record_keeps_its_baseline() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let dns = Arc::new(FakeDns::default());
+    let manager = manager_with_dns(&dir, dns.clone()).await;
+
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    manager
+        .reconcile(common::mihomo_spec(&dir, config), None)
+        .await
+        .unwrap();
+    assert_eq!(*dns.current.lock().unwrap(), vec!["198.18.0.2".to_owned()]);
+
+    // The stop restores at its head, and the restore fails: the record is left
+    // RestorePending with the override still active.
+    dns.fail_restore.store(true, Ordering::SeqCst);
+    manager.stop().await.unwrap();
+    let record: DnsOverrideRecord =
+        serde_json::from_slice(&std::fs::read(record_path(&dir)).unwrap()).unwrap();
+    assert_eq!(record.state, DnsOverrideState::RestorePending);
+    assert_eq!(record.previous, vec!["10.0.0.1".to_owned()]);
+    assert_eq!(*dns.current.lock().unwrap(), vec!["198.18.0.2".to_owned()]);
+
+    // Converging again must re-use that baseline rather than reading back the
+    // override we ourselves installed.
+    dns.fail_restore.store(false, Ordering::SeqCst);
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    manager
+        .reconcile(common::mihomo_spec(&dir, config), None)
+        .await
+        .unwrap();
+    let record: DnsOverrideRecord =
+        serde_json::from_slice(&std::fs::read(record_path(&dir)).unwrap()).unwrap();
+    assert_eq!(
+        record.previous,
+        vec!["10.0.0.1".to_owned()],
+        "the baseline survives a failed restore"
+    );
+
+    // And the proof that it matters: the restore lands on the original.
+    manager.shutdown().await.unwrap();
+    assert_eq!(*dns.current.lock().unwrap(), vec!["10.0.0.1".to_owned()]);
+}
+
+/// An interface with no resolvers is a baseline like any other. Reading an
+/// empty `previous` as "nothing was captured" makes the next converge record
+/// our own override instead, and the host never gets its empty list back.
+#[tokio::test]
+async fn an_empty_baseline_is_still_a_baseline() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let dns = Arc::new(FakeDns::default());
+    *dns.current.lock().unwrap() = Vec::new();
+    let manager = manager_with_dns(&dir, dns.clone()).await;
+
+    for _ in 0..2 {
+        let port = common::free_port();
+        let config =
+            common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+        manager
+            .reconcile(common::mihomo_spec(&dir, config), None)
+            .await
+            .unwrap();
+    }
+    let record: DnsOverrideRecord =
+        serde_json::from_slice(&std::fs::read(record_path(&dir)).unwrap()).unwrap();
+    assert!(
+        record.previous.is_empty(),
+        "the empty baseline must not be replaced by our own override, got {:?}",
+        record.previous
+    );
+
+    manager.shutdown().await.unwrap();
+    assert!(dns.current.lock().unwrap().is_empty());
 }

--- a/crates/nyanpasu-core-manager/tests/fake_backend.rs
+++ b/crates/nyanpasu-core-manager/tests/fake_backend.rs
@@ -1,0 +1,269 @@
+//! The trait-boundary proof: the full control plane runs against an
+//! in-memory backend with no child processes, and the StopProof→Quarantine
+//! contract rows hold (audit §3.2).
+
+mod common;
+
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+use nyanpasu_core_manager::{
+    ConfigInput, ControlOptions, CoreCommand, CoreCommandEnvelope, CoreControl, CoreErrorKind,
+    Error, ManagerOptions, OperationId, OperationOutput, ProbePhase, ProbeResult, ReconcileRequest,
+    manager::{ApplyOutcome, CoreManager},
+    runtime::{BoxFuture, RuntimeBackend, RuntimeInstance, RuntimeLaunchRequest},
+    spec::{InstanceSpec, ResolvedController},
+    state::{InstanceState, InstanceStatus, StopReason},
+};
+use tokio::sync::watch;
+
+#[derive(Default)]
+struct FakeBackend {
+    refuse_stop: Arc<AtomicBool>,
+    launched_epochs: Mutex<Vec<u64>>,
+}
+
+impl RuntimeBackend for FakeBackend {
+    fn launch(
+        &self,
+        request: RuntimeLaunchRequest,
+    ) -> BoxFuture<'_, Result<Box<dyn RuntimeInstance>, Error>> {
+        Box::pin(async move {
+            self.launched_epochs.lock().unwrap().push(request.epoch);
+            let (state_tx, _) = watch::channel(InstanceStatus {
+                state: InstanceState::Starting,
+                health: None,
+            });
+            Ok(Box::new(FakeInstance {
+                spec: request.effective_spec,
+                epoch: request.epoch,
+                controller: request.controller,
+                state_tx,
+                refuse_stop: self.refuse_stop.clone(),
+            }) as Box<dyn RuntimeInstance>)
+        })
+    }
+
+    fn check_config<'a>(&'a self, _spec: &'a InstanceSpec) -> BoxFuture<'a, Result<(), Error>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+struct FakeInstance {
+    spec: InstanceSpec,
+    epoch: u64,
+    controller: ResolvedController,
+    state_tx: watch::Sender<InstanceStatus>,
+    refuse_stop: Arc<AtomicBool>,
+}
+
+impl RuntimeInstance for FakeInstance {
+    fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    fn spec(&self) -> &InstanceSpec {
+        &self.spec
+    }
+
+    fn controller(&self) -> &ResolvedController {
+        &self.controller
+    }
+
+    fn pid(&self) -> Option<u32> {
+        // An embedded runtime has no process; the portable model must cope.
+        None
+    }
+
+    fn state(&self) -> watch::Receiver<InstanceStatus> {
+        self.state_tx.subscribe()
+    }
+
+    fn wait_ready<'a>(&'a self) -> BoxFuture<'a, Result<(), Error>> {
+        Box::pin(async move {
+            let _ = self.state_tx.send(InstanceStatus {
+                state: InstanceState::Running { pid: 0 },
+                health: None,
+            });
+            Ok(())
+        })
+    }
+
+    fn probe_now<'a>(&'a self, _phase: ProbePhase) -> BoxFuture<'a, ProbeResult> {
+        Box::pin(async { ProbeResult::Healthy })
+    }
+
+    fn stop_and_confirm_dead(
+        self: Box<Self>,
+        _timeout: std::time::Duration,
+    ) -> BoxFuture<'static, Result<(), Error>> {
+        Box::pin(async move {
+            if self.refuse_stop.load(Ordering::SeqCst) {
+                return Err(Error::StopUnconfirmed(
+                    "injected: death cannot be proven".into(),
+                ));
+            }
+            let _ = self.state_tx.send(InstanceStatus {
+                state: InstanceState::Stopped(StopReason::User),
+                health: None,
+            });
+            Ok(())
+        })
+    }
+}
+
+async fn control_with_backend(dir: &camino::Utf8Path, backend: Arc<FakeBackend>) -> CoreControl {
+    let manager = CoreManager::builder(ManagerOptions {
+        runtime_dir: Some(dir.join("runtime")),
+        ..ManagerOptions::default()
+    })
+    .runtime_backend(backend)
+    .build()
+    .await
+    .expect("construct manager");
+    CoreControl::spawn(
+        manager,
+        ControlOptions::new(dir.join("sources"), dir.to_owned()),
+    )
+}
+
+fn reconcile_envelope(dir: &camino::Utf8Path, binary: camino::Utf8PathBuf) -> CoreCommandEnvelope {
+    let mut spec = common::mihomo_spec(dir, dir.join("unused.yaml"));
+    spec.core.binary_path = binary;
+    CoreCommandEnvelope {
+        operation_id: OperationId::generate(),
+        command: CoreCommand::Reconcile(Box::new(ReconcileRequest {
+            core: spec.core,
+            // No process ever binds it, but config resolution requires a
+            // controller endpoint.
+            config: ConfigInput::inline(b"external-controller: 127.0.0.1:9090\n".to_vec()),
+            options: spec.options,
+            expected_applied: None,
+        })),
+    }
+}
+
+#[tokio::test]
+async fn the_whole_lifecycle_runs_without_a_single_process() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let backend = Arc::new(FakeBackend::default());
+    let control = control_with_backend(&dir, backend.clone()).await;
+    let first_binary = common::fake_core_bin();
+    let second_binary = dir.join("second-core.exe");
+    std::fs::copy(&first_binary, &second_binary).unwrap();
+
+    // Cold start.
+    let output = control
+        .submit(reconcile_envelope(&dir, first_binary))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+    assert!(matches!(
+        output,
+        OperationOutput::Reconciled(ApplyOutcome::Started { .. })
+    ));
+
+    // A different binary is a spec change: classify → switch, with the old
+    // instance's death proven in between.
+    let output = control
+        .submit(reconcile_envelope(&dir, second_binary))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+    assert!(
+        matches!(
+            output,
+            OperationOutput::Reconciled(ApplyOutcome::Switched { .. })
+        ),
+        "expected a switch, got {output:?}"
+    );
+    assert_eq!(*backend.launched_epochs.lock().unwrap(), vec![1, 2]);
+
+    let output = control
+        .submit(CoreCommandEnvelope {
+            operation_id: OperationId::generate(),
+            command: CoreCommand::Stop,
+        })
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+    assert!(matches!(output, OperationOutput::Stopped));
+
+    control
+        .submit(CoreCommandEnvelope {
+            operation_id: OperationId::generate(),
+            command: CoreCommand::Shutdown,
+        })
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn an_unproven_stop_quarantines_and_blocks_every_mutation() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let backend = Arc::new(FakeBackend::default());
+    let control = control_with_backend(&dir, backend.clone()).await;
+    let first_binary = common::fake_core_bin();
+    let second_binary = dir.join("second-core.exe");
+    std::fs::copy(&first_binary, &second_binary).unwrap();
+
+    control
+        .submit(reconcile_envelope(&dir, first_binary.clone()))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+
+    // From now on the running instance refuses to prove its death.
+    backend.refuse_stop.store(true, Ordering::SeqCst);
+    let error = control
+        .submit(reconcile_envelope(&dir, second_binary))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::StopUnconfirmed));
+
+    // No StopProof → no next owner: every further mutation is refused.
+    let error = control
+        .submit(reconcile_envelope(&dir, first_binary))
+        .unwrap()
+        .wait()
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::Quarantined));
+
+    // Recovery demands proof of death. The fake backend never wrote the
+    // process backend's authoritative pid record, so the proof is
+    // unavailable and the quarantine honestly stays.
+    //
+    // Known phase-1 gap, on the audit ledger: recovery proof is pid-file
+    // mechanics inside the manager, not yet routed through RuntimeBackend.
+    let error = control
+        .submit(CoreCommandEnvelope {
+            operation_id: OperationId::generate(),
+            command: CoreCommand::Recover,
+        })
+        .unwrap()
+        .wait()
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::Quarantined));
+
+    control
+        .submit(CoreCommandEnvelope {
+            operation_id: OperationId::generate(),
+            command: CoreCommand::Shutdown,
+        })
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+}

--- a/crates/nyanpasu-core-manager/tests/fake_backend.rs
+++ b/crates/nyanpasu-core-manager/tests/fake_backend.rs
@@ -343,3 +343,41 @@ async fn an_executor_panic_gives_every_operation_a_terminal_state_and_reports_di
         .unwrap_err();
     assert_eq!(error.kind, Some(CoreErrorKind::ShuttingDown));
 }
+
+/// The latch has to land before the command is queued. With the old order a
+/// reconcile that was already waiting still ran, so a shutdown could hand back
+/// a *running* core.
+#[tokio::test]
+async fn shutdown_refuses_already_queued_work_and_reports_clean() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let backend = Arc::new(FakeBackend::default());
+    backend.gate_launch.store(true, Ordering::SeqCst);
+    let control = control_with_backend(&dir, backend.clone()).await;
+    let binary = common::fake_core_bin();
+
+    let running = control
+        .submit(reconcile_envelope(&dir, binary.clone()))
+        .unwrap();
+    backend.launch_started.notified().await;
+    let queued = control.submit(reconcile_envelope(&dir, binary)).unwrap();
+
+    let shutting_down = tokio::spawn({
+        let control = control.clone();
+        async move { control.shutdown().await }
+    });
+    backend.release_launch.notify_one();
+
+    running.wait().await.unwrap();
+    let error = queued.wait().await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::ShuttingDown));
+    shutting_down.await.unwrap().unwrap();
+    assert_eq!(
+        control.until_closed().await,
+        nyanpasu_core_manager::ExecutorExit::Clean
+    );
+    assert_eq!(
+        backend.launched_epochs.lock().unwrap().len(),
+        1,
+        "the queued reconcile must not launch a core behind the shutdown"
+    );
+}

--- a/crates/nyanpasu-core-manager/tests/fake_backend.rs
+++ b/crates/nyanpasu-core-manager/tests/fake_backend.rs
@@ -11,18 +11,28 @@ use std::sync::{
 
 use nyanpasu_core_manager::{
     ConfigInput, ControlOptions, CoreCommand, CoreCommandEnvelope, CoreControl, CoreErrorKind,
-    Error, ManagerOptions, OperationId, OperationOutput, ProbePhase, ProbeResult, ReconcileRequest,
+    Error, ManagerOptions, OperationId, OperationOutput, OperationState, ProbePhase, ProbeResult,
+    ReconcileRequest,
     manager::{ApplyOutcome, CoreManager},
     runtime::{BoxFuture, RuntimeBackend, RuntimeInstance, RuntimeLaunchRequest},
     spec::{InstanceSpec, ResolvedController},
     state::{InstanceState, InstanceStatus, StopReason},
 };
-use tokio::sync::watch;
+use tokio::sync::{Notify, watch};
 
 #[derive(Default)]
 struct FakeBackend {
     refuse_stop: Arc<AtomicBool>,
     launched_epochs: Mutex<Vec<u64>>,
+    /// Holds the first launch inside the executor so a test can fill the queue
+    /// behind a transaction that is provably running.
+    gate_launch: AtomicBool,
+    gate_taken: AtomicBool,
+    launch_started: Notify,
+    release_launch: Notify,
+    /// Injected here rather than in the control plane: the executor's panic
+    /// boundary must be provable without a production-side hook.
+    panic_on_launch: AtomicBool,
 }
 
 impl RuntimeBackend for FakeBackend {
@@ -32,6 +42,16 @@ impl RuntimeBackend for FakeBackend {
     ) -> BoxFuture<'_, Result<Box<dyn RuntimeInstance>, Error>> {
         Box::pin(async move {
             self.launched_epochs.lock().unwrap().push(request.epoch);
+            if self.gate_launch.load(Ordering::SeqCst)
+                && !self.gate_taken.swap(true, Ordering::SeqCst)
+            {
+                self.launch_started.notify_one();
+                self.release_launch.notified().await;
+            }
+            assert!(
+                !self.panic_on_launch.load(Ordering::SeqCst),
+                "injected launch panic"
+            );
             let (state_tx, _) = watch::channel(InstanceStatus {
                 state: InstanceState::Starting,
                 health: None,
@@ -266,4 +286,60 @@ async fn an_unproven_stop_quarantines_and_blocks_every_mutation() {
         .wait()
         .await
         .unwrap();
+}
+
+/// A panicking transaction used to take the executor down with it: the
+/// operation that panicked and everything queued behind it stayed `Queued` or
+/// `Running` forever, because the registry kept their watch senders alive.
+#[tokio::test]
+async fn an_executor_panic_gives_every_operation_a_terminal_state_and_reports_died() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let backend = Arc::new(FakeBackend::default());
+    backend.gate_launch.store(true, Ordering::SeqCst);
+    backend.panic_on_launch.store(true, Ordering::SeqCst);
+    let control = control_with_backend(&dir, backend.clone()).await;
+
+    let panicking = control
+        .submit(reconcile_envelope(&dir, common::fake_core_bin()))
+        .unwrap();
+    // The second operation is admitted while the first is provably inside the
+    // executor, so it is sitting in the queue when the panic happens.
+    backend.launch_started.notified().await;
+    let queued = control
+        .submit(CoreCommandEnvelope {
+            operation_id: OperationId::generate(),
+            command: CoreCommand::Stop,
+        })
+        .unwrap();
+    // Dropped on purpose: the wire's submit answers from the admission
+    // snapshot and keeps nothing, so the registry has to record the terminal
+    // state with no receiver listening. Holding the handle here would keep a
+    // `watch` receiver alive and hide exactly that.
+    let queued_id = queued.id();
+    drop(queued);
+    backend.release_launch.notify_one();
+
+    let error = panicking.wait().await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::Internal));
+    assert!(
+        matches!(
+            control.operation(queued_id),
+            Some(OperationState::Failed(ref error)) if error.kind == Some(CoreErrorKind::Internal)
+        ),
+        "a queued operation whose handle was dropped still needs a terminal state, got {:?}",
+        control.operation(queued_id)
+    );
+    assert_eq!(
+        control.until_closed().await,
+        nyanpasu_core_manager::ExecutorExit::Died
+    );
+
+    // A dead executor admits nothing further.
+    let error = control
+        .submit(CoreCommandEnvelope {
+            operation_id: OperationId::generate(),
+            command: CoreCommand::Stop,
+        })
+        .unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::ShuttingDown));
 }

--- a/crates/nyanpasu-core-manager/tests/reconcile.rs
+++ b/crates/nyanpasu-core-manager/tests/reconcile.rs
@@ -1,0 +1,162 @@
+//! The unified `reconcile` entry: cold start, convergence dispatch, CAS, and
+//! the clean-abort guarantee of the internal check.
+
+mod common;
+
+use nyanpasu_core_manager::{
+    CoreState, Error, ManagerOptions, RevisionId,
+    manager::{ApplyOutcome, CoreManager},
+};
+
+async fn manager(dir: &camino::Utf8Path) -> CoreManager {
+    CoreManager::new(ManagerOptions {
+        runtime_dir: Some(dir.join("runtime")),
+        ..ManagerOptions::default()
+    })
+    .await
+    .expect("construct manager")
+}
+
+#[tokio::test]
+async fn reconcile_starts_cold_then_noops_on_the_same_config() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let spec = common::mihomo_spec(&dir, config);
+    let manager = manager(&dir).await;
+
+    let outcome = manager.reconcile(spec.clone(), None).await.unwrap();
+    let ApplyOutcome::Started { revision } = outcome else {
+        panic!("cold reconcile must report Started, got {outcome:?}");
+    };
+    assert!(matches!(manager.status().state, CoreState::Running { .. }));
+
+    // The same source config converges to Noop, gated by the real revision.
+    let outcome = manager.reconcile(spec, Some(revision.id())).await.unwrap();
+    assert!(matches!(outcome, ApplyOutcome::Noop { .. }));
+
+    manager.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn reconcile_with_a_stale_expectation_changes_nothing() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let spec = common::mihomo_spec(&dir, config);
+    let manager = manager(&dir).await;
+
+    let ApplyOutcome::Started { revision } = manager.reconcile(spec.clone(), None).await.unwrap()
+    else {
+        panic!("cold reconcile must report Started");
+    };
+    let running = manager.status();
+
+    let stale = RevisionId {
+        epoch: 99,
+        generation: 9,
+        effective_hash: "deadbeefdeadbeef".to_owned(),
+    };
+    let error = manager
+        .reconcile(spec, Some(stale))
+        .await
+        .expect_err("stale expectation must conflict");
+    let Error::RevisionConflict { actual, .. } = error else {
+        panic!("expected RevisionConflict, got {error}");
+    };
+    assert_eq!(actual, Some(revision.id()));
+    // Zero side effects: the runtime kept running on the same revision.
+    let status = manager.status();
+    assert_eq!(status.state, running.state);
+    assert_eq!(
+        status.revision.as_ref().map(|revision| revision.id()),
+        Some(revision.id())
+    );
+
+    manager.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn reconcile_against_a_stopped_manager_rejects_a_believed_revision() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let manager = manager(&dir).await;
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let spec = common::mihomo_spec(&dir, config);
+
+    let expected = RevisionId {
+        epoch: 1,
+        generation: 1,
+        effective_hash: "0123456789abcdef".to_owned(),
+    };
+    let error = manager
+        .reconcile(spec, Some(expected))
+        .await
+        .expect_err("a believed revision cannot match a stopped manager");
+    let Error::RevisionConflict { actual, .. } = error else {
+        panic!("expected RevisionConflict, got {error}");
+    };
+    assert_eq!(actual, None);
+    // The conflict must not have started anything.
+    assert!(matches!(manager.status().state, CoreState::Stopped { .. }));
+
+    manager.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn a_rejected_config_aborts_cleanly_while_the_old_core_keeps_running() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let spec = common::mihomo_spec(&dir, config);
+    let manager = manager(&dir).await;
+
+    let ApplyOutcome::Started { revision } = manager.reconcile(spec.clone(), None).await.unwrap()
+    else {
+        panic!("cold reconcile must report Started");
+    };
+
+    // Semantic rejection from the core's own dry run, inside the transaction.
+    let rejected = common::write_config(
+        &dir,
+        &format!(
+            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  check-fail: port already in use\n"
+        ),
+    );
+    let mut rejected_spec = spec.clone();
+    rejected_spec.config_path = rejected;
+    let error = manager
+        .reconcile(rejected_spec, Some(revision.id()))
+        .await
+        .expect_err("the dry-run rejection must abort the transaction");
+    assert!(matches!(error, Error::ConfigCheckFailed(_)), "{error}");
+
+    // Clean abort: the old core is still running on the old revision.
+    let status = manager.status();
+    assert!(matches!(status.state, CoreState::Running { .. }));
+    assert_eq!(
+        status.revision.as_ref().map(|revision| revision.id()),
+        Some(revision.id())
+    );
+
+    // A parse failure aborts just as cleanly, without touching a process.
+    let malformed = common::write_config(&dir, "external-controller: [unclosed\n");
+    let mut malformed_spec = spec.clone();
+    malformed_spec.config_path = malformed;
+    let error = manager
+        .reconcile(malformed_spec, Some(revision.id()))
+        .await
+        .expect_err("a malformed config must abort the transaction");
+    assert!(
+        matches!(error, Error::Yaml(_) | Error::InvalidConfig(_)),
+        "{error}"
+    );
+    let status = manager.status();
+    assert!(matches!(status.state, CoreState::Running { .. }));
+    assert_eq!(
+        status.revision.as_ref().map(|revision| revision.id()),
+        Some(revision.id())
+    );
+
+    manager.shutdown().await.unwrap();
+}

--- a/crates/nyanpasu-core-metadata/src/error_kind.rs
+++ b/crates/nyanpasu-core-metadata/src/error_kind.rs
@@ -47,6 +47,9 @@ pub enum CoreErrorKind {
     /// The control endpoint cannot be reached: transport failure, daemon not
     /// running, or the endpoint is reconnecting. Retryable by definition.
     BackendUnavailable,
+    /// The control plane itself failed — an executor died or a reply channel
+    /// broke. Not retryable; the host must treat this as fatal.
+    Internal,
 }
 
 impl CoreErrorKind {
@@ -70,6 +73,7 @@ impl CoreErrorKind {
         Self::QueueFull,
         Self::OperationConflict,
         Self::BackendUnavailable,
+        Self::Internal,
     ];
 
     /// The wire string. `serde` derives the same spelling from
@@ -93,6 +97,7 @@ impl CoreErrorKind {
             Self::QueueFull => "queue_full",
             Self::OperationConflict => "operation_conflict",
             Self::BackendUnavailable => "backend_unavailable",
+            Self::Internal => "internal",
         }
     }
 
@@ -161,6 +166,7 @@ mod tests {
             CoreErrorKind::BackendUnavailable.as_str(),
             "backend_unavailable"
         );
+        assert_eq!(CoreErrorKind::Internal.as_str(), "internal");
     }
 
     #[test]

--- a/crates/nyanpasu-core-metadata/src/error_kind.rs
+++ b/crates/nyanpasu-core-metadata/src/error_kind.rs
@@ -36,6 +36,17 @@ pub enum CoreErrorKind {
     ApplyRollbackFailed,
     /// A core process could not be proven dead; the manager is now quarantined.
     StopUnconfirmed,
+    /// The control plane is shutting down and admits no new operations.
+    ShuttingDown,
+    /// The bounded operation queue is full; retry after in-flight work drains.
+    QueueFull,
+    /// The `OperationId` was already used with a different payload, or the
+    /// operation cannot run concurrently with one that owns the endpoint
+    /// (for example a host handoff in progress).
+    OperationConflict,
+    /// The control endpoint cannot be reached: transport failure, daemon not
+    /// running, or the endpoint is reconnecting. Retryable by definition.
+    BackendUnavailable,
 }
 
 impl CoreErrorKind {
@@ -55,6 +66,10 @@ impl CoreErrorKind {
         Self::ApplyFailed,
         Self::ApplyRollbackFailed,
         Self::StopUnconfirmed,
+        Self::ShuttingDown,
+        Self::QueueFull,
+        Self::OperationConflict,
+        Self::BackendUnavailable,
     ];
 
     /// The wire string. `serde` derives the same spelling from
@@ -74,6 +89,10 @@ impl CoreErrorKind {
             Self::ApplyFailed => "apply_failed",
             Self::ApplyRollbackFailed => "apply_rollback_failed",
             Self::StopUnconfirmed => "stop_unconfirmed",
+            Self::ShuttingDown => "shutting_down",
+            Self::QueueFull => "queue_full",
+            Self::OperationConflict => "operation_conflict",
+            Self::BackendUnavailable => "backend_unavailable",
         }
     }
 
@@ -132,6 +151,16 @@ mod tests {
             "apply_rollback_failed"
         );
         assert_eq!(CoreErrorKind::StopUnconfirmed.as_str(), "stop_unconfirmed");
+        assert_eq!(CoreErrorKind::ShuttingDown.as_str(), "shutting_down");
+        assert_eq!(CoreErrorKind::QueueFull.as_str(), "queue_full");
+        assert_eq!(
+            CoreErrorKind::OperationConflict.as_str(),
+            "operation_conflict"
+        );
+        assert_eq!(
+            CoreErrorKind::BackendUnavailable.as_str(),
+            "backend_unavailable"
+        );
     }
 
     #[test]

--- a/crates/nyanpasu-core-metadata/src/error_kind.rs
+++ b/crates/nyanpasu-core-metadata/src/error_kind.rs
@@ -101,6 +101,14 @@ impl CoreErrorKind {
         }
     }
 
+    /// Whether a failure of this kind is retryable regardless of what produced
+    /// it. Everything else defaults to non-retryable and the producer overrides
+    /// where it knows better, which is why this is a default and not the
+    /// answer: the retryability that reaches the wire is the producer's.
+    pub const fn default_retryable(&self) -> bool {
+        matches!(self, Self::QueueFull | Self::BackendUnavailable)
+    }
+
     /// The kind a wire string names, or `None` when this build does not know it.
     ///
     /// `None` is not an error: a newer service may classify a failure this build

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -70,6 +70,11 @@ pub(crate) const MSG_CORE_NOT_STARTED: &str = "core have not been started yet";
 pub(crate) struct OpError {
     kind: Option<CoreErrorKind>,
     message: String,
+    /// The producer's answer, when it has one. Left `None` everywhere the
+    /// service is only classifying a failure it observed: the kind's default
+    /// is the client's fallback, and repeating it here would turn a guess into
+    /// an assertion on the wire.
+    retryable: Option<bool>,
 }
 
 impl OpError {
@@ -79,6 +84,7 @@ impl OpError {
         Self {
             kind: None,
             message: message.into(),
+            retryable: None,
         }
     }
 
@@ -88,7 +94,15 @@ impl OpError {
         Self {
             kind: Some(kind),
             message: message.into(),
+            retryable: None,
         }
+    }
+
+    /// Pins retryability the control plane already decided, rather than leaving
+    /// the client to infer it from the kind.
+    fn retryable(mut self, retryable: bool) -> Self {
+        self.retryable = Some(retryable);
+        self
     }
 
     /// The error envelope for this failure, `error_kind` included.
@@ -96,7 +110,7 @@ impl OpError {
     where
         T: Serialize + DeserializeOwned + std::fmt::Debug,
     {
-        RBuilder::other_error_with_kind(Cow::Owned(self.message), self.kind)
+        RBuilder::other_error_with_kind(Cow::Owned(self.message), self.kind, self.retryable)
     }
 }
 
@@ -104,6 +118,7 @@ impl From<ManagerError> for OpError {
     fn from(error: ManagerError) -> Self {
         Self {
             kind: error.kind(),
+            retryable: None,
             message: match &error {
                 // The legacy wire string the GUI already branches on, so
                 // `apply` on a stopped core reads exactly like `restart` on
@@ -803,10 +818,12 @@ fn echo_commits(state: &OperationState) -> bool {
 }
 
 fn op_error_from_control(error: ControlError) -> OpError {
+    let retryable = error.retryable;
     match error.kind {
         Some(kind) => OpError::with_kind(kind, error.message),
         None => OpError::plain(error.message),
     }
+    .retryable(retryable)
 }
 
 fn map_operation(id: OperationId, state: OperationState) -> OperationInfo {

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -6,14 +6,21 @@ use std::{
 
 use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_core_manager::{
-    ApplyOutcome, ConfigRevision, CoreErrorKind, CoreKind, CoreManager as Manager, CoreSpec,
-    CoreState as ManagerCoreState, CoreStatus, Error as ManagerError, HealthState, HealthStatus,
-    Host, InstanceOptions, InstanceSpec, LocalIpcPolicy, LogFrame, LogLevel, ManagerOptions,
-    RevisionId,
+    ApplyOutcome, ConfigInput, ConfigRevision, ControlOptions, CoreCommand, CoreCommandEnvelope,
+    CoreControl, CoreError as ControlError, CoreErrorKind, CoreKind, CoreManager as Manager,
+    CoreSpec, CoreState as ManagerCoreState, CoreStatus, Error as ManagerError, HealthState,
+    HealthStatus, Host, InstanceOptions, InstanceSpec, LocalIpcPolicy, LogFrame, LogLevel,
+    ManagerOptions, OperationId, OperationOutput, OperationState, ReconcileRequest, RevisionId,
 };
 use nyanpasu_ipc::api::{
     R, RBuilder,
-    core::apply::{ApplyOutcomeKind, CoreApplyData},
+    core::{
+        apply::{ApplyOutcomeKind, CoreApplyData},
+        v2::{
+            CoreCommandInfo, CoreOperationReq, CoreSubmitReq, OperationErrorInfo, OperationInfo,
+            OperationOutputInfo, OperationPhase, ReconcileOutcomeInfo, ReconcileOutcomeKind,
+        },
+    },
     status::{
         ConfigRevisionInfo, CoreControllerInfo, CoreHealthInfo, CoreHealthState, CoreInfos,
         CoreState, CoreStateDetail, RevisionIdInfo,
@@ -36,6 +43,10 @@ const CORE_LOG_TARGET: &str = "nyanpasu_service::core";
 /// bound is testable without the runtime crate's tests interfering with each
 /// other.
 const MAX_CONCURRENT_CHECKS: usize = 2;
+
+/// Long-poll clamp for `/v2/core/operation`, kept well under the route
+/// middleware's 120s liveness bound.
+const MAX_OPERATION_WAIT_MS: u64 = 90_000;
 
 /// Legacy wire strings the GUI branches on. These are protocol, not
 /// diagnostics: changing any of them is a breaking change to clash-nyanpasu.
@@ -105,6 +116,10 @@ impl From<anyhow::Error> for OpError {
 
 struct Inner {
     manager: Manager,
+    /// The v2 control plane over the same manager: bounded queue, idempotency
+    /// registry, cancellation isolation. The v1 methods below keep calling the
+    /// manager directly until the bridge stage deletes them.
+    control: CoreControl,
     /// Wire-type echo: the manager knows nothing about the alpha variants.
     ///
     /// A watch channel rather than a lock, because committing the echo has to be
@@ -115,7 +130,7 @@ struct Inner {
     /// channel would never close and the task would never exit.
     requested_core: watch::Sender<Option<CoreType>>,
     /// Serializes adapter-level control ops and carries the closing latch.
-    control: tokio::sync::Mutex<ControlState>,
+    control_state: tokio::sync::Mutex<ControlState>,
     /// F2 lands here too; see §2.2.
     check_slots: Semaphore,
 }
@@ -133,18 +148,23 @@ impl CoreManagerService {
     pub async fn new(
         runtime_dir: Utf8PathBuf,
         local_ipc_policy: LocalIpcPolicy,
+        data_dir: Utf8PathBuf,
     ) -> Result<Self, anyhow::Error> {
+        let source_dir = runtime_dir.join("v2-sources");
         let manager = Manager::new(ManagerOptions {
             runtime_dir: Some(runtime_dir),
             local_ipc_policy,
             ..ManagerOptions::default()
         })
         .await?;
+        let core_control =
+            CoreControl::spawn(manager.clone(), ControlOptions::new(source_dir, data_dir));
         Ok(Self {
             inner: Arc::new(Inner {
                 manager,
+                control: core_control,
                 requested_core: watch::Sender::new(None),
-                control: tokio::sync::Mutex::new(ControlState { closing: false }),
+                control_state: tokio::sync::Mutex::new(ControlState { closing: false }),
                 check_slots: Semaphore::new(MAX_CONCURRENT_CHECKS),
             }),
         })
@@ -186,7 +206,7 @@ impl CoreManagerService {
 
     /// Stop the core and clean runtime artifacts. Idempotent; errors are logged, not returned.
     pub async fn shutdown(&self) {
-        let mut control = self.inner.control.lock().await;
+        let mut control = self.inner.control_state.lock().await;
         if control.closing {
             return;
         }
@@ -204,7 +224,7 @@ impl CoreManagerService {
         core_type: &CoreType,
         config_path: &Utf8Path,
     ) -> Result<(), anyhow::Error> {
-        let control = self.inner.control.lock().await;
+        let control = self.inner.control_state.lock().await;
         if control.closing {
             anyhow::bail!("service is shutting down");
         }
@@ -236,7 +256,7 @@ impl CoreManagerService {
     }
 
     pub async fn stop(&self) -> Result<(), anyhow::Error> {
-        let control = self.inner.control.lock().await;
+        let control = self.inner.control_state.lock().await;
         if control.closing {
             anyhow::bail!("service is shutting down");
         }
@@ -248,7 +268,7 @@ impl CoreManagerService {
     }
 
     pub async fn restart(&self) -> Result<(), anyhow::Error> {
-        let control = self.inner.control.lock().await;
+        let control = self.inner.control_state.lock().await;
         if control.closing {
             anyhow::bail!("service is shutting down");
         }
@@ -273,7 +293,7 @@ impl CoreManagerService {
         config_file: &Path,
         expected_revision: Option<&RevisionIdInfo>,
     ) -> Result<CoreApplyData, OpError> {
-        let control = self.inner.control.lock().await;
+        let control = self.inner.control_state.lock().await;
         if control.closing {
             return Err(OpError::plain("service is shutting down"));
         }
@@ -312,7 +332,7 @@ impl CoreManagerService {
             // Released before the check runs: it spawns the core binary, and
             // holding the adapter latch across an external process would block
             // start/stop/restart for as long as that takes.
-            let control = self.inner.control.lock().await;
+            let control = self.inner.control_state.lock().await;
             if control.closing {
                 return Err(OpError::plain("service is shutting down"));
             }
@@ -335,7 +355,7 @@ impl CoreManagerService {
     /// confirmed. Idempotent: succeeds when nothing was quarantined.
     #[instrument(skip(self))]
     pub async fn recover(&self) -> Result<(), OpError> {
-        let control = self.inner.control.lock().await;
+        let control = self.inner.control_state.lock().await;
         if control.closing {
             return Err(OpError::plain("service is shutting down"));
         }
@@ -358,6 +378,92 @@ impl CoreManagerService {
             .manager
             .log_dir()
             .map(|dir| dir.as_std_path().to_path_buf())
+    }
+
+    /// `POST /v2/core/submit`: admission into the control plane. Synchronous —
+    /// the executor owns the transaction from here on, and a dropped
+    /// connection cancels nothing.
+    pub fn submit_v2(
+        &self,
+        infos: &RuntimeInfos,
+        request: &CoreSubmitReq<'_>,
+    ) -> Result<OperationInfo, OpError> {
+        let id: OperationId = request.operation_id.parse().map_err(|_| {
+            OpError::plain(format!("malformed operation id: {}", request.operation_id))
+        })?;
+        let command = match &request.command {
+            CoreCommandInfo::Reconcile {
+                core_type,
+                config,
+                expected_digest,
+                expected_applied,
+            } => {
+                // Binary resolution and kind mapping are host policy; reuse
+                // the v1 spec builder for both. The placeholder config path is
+                // never read — the config ships as bytes and the control plane
+                // materializes it itself.
+                let spec = self.instance_spec(infos, core_type, Utf8PathBuf::new())?;
+                self.watch_reconcile_echo(id, core_type.clone().into_owned());
+                CoreCommand::Reconcile(Box::new(ReconcileRequest {
+                    core: spec.core,
+                    config: ConfigInput::Inline {
+                        bytes: config.as_bytes().to_vec(),
+                        expected_digest: expected_digest.as_ref().map(|digest| digest.to_string()),
+                    },
+                    options: spec.options,
+                    expected_applied: expected_applied.as_ref().map(map_revision_id),
+                }))
+            }
+            CoreCommandInfo::Stop => CoreCommand::Stop,
+            CoreCommandInfo::Recover => CoreCommand::Recover,
+        };
+        let handle = self
+            .inner
+            .control
+            .submit(CoreCommandEnvelope {
+                operation_id: id,
+                command,
+            })
+            .map_err(op_error_from_control)?;
+        Ok(map_operation(handle.id(), handle.state()))
+    }
+
+    /// `POST /v2/core/operation`: registry query, optionally long-polling.
+    pub async fn operation_v2(
+        &self,
+        request: &CoreOperationReq<'_>,
+    ) -> Result<OperationInfo, OpError> {
+        let id: OperationId = request.operation_id.parse().map_err(|_| {
+            OpError::plain(format!("malformed operation id: {}", request.operation_id))
+        })?;
+        let state = match request.wait_ms {
+            Some(wait_ms) => {
+                let bound = std::time::Duration::from_millis(wait_ms.min(MAX_OPERATION_WAIT_MS));
+                self.inner.control.wait_operation(id, bound).await
+            }
+            None => self.inner.control.operation(id),
+        };
+        state.map(|state| map_operation(id, state)).ok_or_else(|| {
+            OpError::plain(format!(
+                "unknown operation {id}: the registry entry was evicted or never existed; \
+                 re-read /v2/core/status and rely on the revision CAS"
+            ))
+        })
+    }
+
+    /// Keeps the v1 wire-type echo truthful for v2 reconciles: committed only
+    /// when the transaction succeeds, observed from the registry rather than
+    /// assumed at admission.
+    fn watch_reconcile_echo(&self, id: OperationId, core_type: CoreType) {
+        let service = self.clone();
+        tokio::spawn(async move {
+            let bound = std::time::Duration::from_millis(MAX_OPERATION_WAIT_MS * 2);
+            if let Some(OperationState::Succeeded(_)) =
+                service.inner.control.wait_operation(id, bound).await
+            {
+                service.publish_requested_core(Some(&core_type));
+            }
+        });
     }
 
     /// Publish the wire-type echo the bridge projects into status snapshots.
@@ -601,6 +707,87 @@ fn map_revision_id(info: &RevisionIdInfo) -> RevisionId {
 /// keep every warning. `ApplyOutcome` is not `#[non_exhaustive]`: if the
 /// manager grows a variant, this match must fail to compile rather than
 /// silently mislabel it.
+fn op_error_from_control(error: ControlError) -> OpError {
+    match error.kind {
+        Some(kind) => OpError::with_kind(kind, error.message),
+        None => OpError::plain(error.message),
+    }
+}
+
+fn map_operation(id: OperationId, state: OperationState) -> OperationInfo {
+    let (phase, output, error) = match state {
+        OperationState::Queued => (OperationPhase::Queued, None, None),
+        OperationState::Running => (OperationPhase::Running, None, None),
+        OperationState::Succeeded(output) => (
+            OperationPhase::Succeeded,
+            Some(map_operation_output(output)),
+            None,
+        ),
+        OperationState::Failed(failure) => (
+            OperationPhase::Failed,
+            None,
+            Some(OperationErrorInfo {
+                kind: failure.kind.map(|kind| Cow::Borrowed(kind.as_str())),
+                message: failure.message,
+                retryable: failure.retryable,
+            }),
+        ),
+    };
+    OperationInfo {
+        id: id.to_string(),
+        phase,
+        output,
+        error,
+    }
+}
+
+fn map_operation_output(output: OperationOutput) -> OperationOutputInfo {
+    match output {
+        OperationOutput::Reconciled(outcome) => {
+            OperationOutputInfo::Reconciled(map_reconcile_outcome(&outcome))
+        }
+        OperationOutput::Stopped => OperationOutputInfo::Stopped,
+        OperationOutput::Recovered => OperationOutputInfo::Recovered,
+        OperationOutput::ShutDown => OperationOutputInfo::ShutDown,
+    }
+}
+
+/// The v2 sibling of [`map_apply_outcome`]: same durability unwrapping, plus
+/// the `Started` variant only `reconcile` produces.
+fn map_reconcile_outcome(outcome: &ApplyOutcome) -> ReconcileOutcomeInfo {
+    let mut warnings = Vec::new();
+    let mut current = outcome;
+    while let ApplyOutcome::DurabilityUncertain { outcome, warning } = current {
+        warnings.push(warning.clone());
+        current = &**outcome;
+    }
+    let (kind, revision, failed_apply) = match current {
+        ApplyOutcome::Started { revision } => (ReconcileOutcomeKind::Started, revision, None),
+        ApplyOutcome::Noop { revision } => (ReconcileOutcomeKind::Noop, revision, None),
+        ApplyOutcome::Patched { revision } => (ReconcileOutcomeKind::Patched, revision, None),
+        ApplyOutcome::Reloaded { revision } => (ReconcileOutcomeKind::Reloaded, revision, None),
+        ApplyOutcome::Restarted { revision } => (ReconcileOutcomeKind::Restarted, revision, None),
+        ApplyOutcome::Switched { revision } => (ReconcileOutcomeKind::Switched, revision, None),
+        ApplyOutcome::RolledBack {
+            revision,
+            failed_apply,
+        } => (
+            ReconcileOutcomeKind::RolledBack,
+            revision,
+            Some(failed_apply.clone()),
+        ),
+        ApplyOutcome::DurabilityUncertain { .. } => {
+            unreachable!("unwrapped by the loop above")
+        }
+    };
+    ReconcileOutcomeInfo {
+        outcome: kind,
+        revision: map_revision(revision),
+        warning: (!warnings.is_empty()).then(|| warnings.join("; ")),
+        failed_apply,
+    }
+}
+
 fn map_apply_outcome(outcome: &ApplyOutcome) -> CoreApplyData {
     let mut warnings = Vec::new();
     let mut current = outcome;
@@ -1265,7 +1452,9 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let runtime_dir = Utf8PathBuf::from_path_buf(dir.path().join("core-runtime"))
             .expect("temp path is UTF-8");
-        let service = CoreManagerService::new(runtime_dir, LocalIpcPolicy::Disable)
+        let data_dir = Utf8PathBuf::from_path_buf(dir.path().join("nyanpasu-data"))
+            .expect("temp path is UTF-8");
+        let service = CoreManagerService::new(runtime_dir, LocalIpcPolicy::Disable, data_dir)
             .await
             .expect("the manager builds on a fresh runtime dir");
         (dir, service)

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -628,6 +628,11 @@ fn map_apply_outcome(outcome: &ApplyOutcome) -> CoreApplyData {
         ApplyOutcome::DurabilityUncertain { .. } => {
             unreachable!("unwrapped by the loop above")
         }
+        // The v1 apply handler feeds this from `apply_config`, which requires
+        // a running core; only the v2 `reconcile` path can cold-start.
+        ApplyOutcome::Started { .. } => {
+            unreachable!("apply_config never cold-starts a core")
+        }
     };
     CoreApplyData {
         outcome: kind,

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -10,8 +10,8 @@ use nyanpasu_core_manager::{
     CoreControl, CoreError as ControlError, CoreErrorKind, CoreKind, CoreManager as Manager,
     CoreSpec, CoreState as ManagerCoreState, CoreStatus, Error as ManagerError, ExecutorExit,
     HealthState, HealthStatus, Host, InstanceOptions, InstanceSpec, LocalIpcPolicy, LogFrame,
-    LogLevel, ManagerOptions, OperationId, OperationOutput, OperationState, ReconcileRequest,
-    RevisionId,
+    LogLevel, ManagerOptions, OperationHandle, OperationId, OperationOutput, OperationState,
+    ReconcileRequest, RevisionId,
 };
 use nyanpasu_ipc::api::{
     R, RBuilder,
@@ -136,6 +136,13 @@ struct Inner {
     /// `Arc<Inner>` inside that task would keep the manager alive, so its watch
     /// channel would never close and the task would never exit.
     requested_core: watch::Sender<Option<CoreType>>,
+    /// The executor sequence of the newest reconcile whose echo has been
+    /// applied. Reconciles run serially, but the tasks watching them do not:
+    /// two completions can be observed in either order, and applying the older
+    /// one second would leave the wire claiming a type the runtime no longer
+    /// has. Guarding the read-compare-write together is what makes the echo
+    /// last-writer-by-execution-order rather than last-observer-wins.
+    echo_applied: parking_lot::Mutex<Option<u64>>,
     /// Serializes adapter-level control ops and carries the closing latch.
     control_state: tokio::sync::Mutex<ControlState>,
     /// F2 lands here too; see §2.2.
@@ -171,6 +178,7 @@ impl CoreManagerService {
                 manager,
                 control: core_control,
                 requested_core: watch::Sender::new(None),
+                echo_applied: parking_lot::Mutex::new(None),
                 control_state: tokio::sync::Mutex::new(ControlState { closing: false }),
                 check_slots: Semaphore::new(MAX_CONCURRENT_CHECKS),
             }),
@@ -427,6 +435,7 @@ impl CoreManagerService {
         let id: OperationId = request.operation_id.parse().map_err(|_| {
             OpError::plain(format!("malformed operation id: {}", request.operation_id))
         })?;
+        let mut echoed_core = None;
         let command = match &request.command {
             CoreCommandInfo::Reconcile {
                 core_type,
@@ -439,7 +448,7 @@ impl CoreManagerService {
                 // never read — the config ships as bytes and the control plane
                 // materializes it itself.
                 let spec = self.instance_spec(infos, core_type, Utf8PathBuf::new())?;
-                self.watch_reconcile_echo(id, core_type.clone().into_owned());
+                echoed_core = Some(core_type.clone().into_owned());
                 CoreCommand::Reconcile(Box::new(ReconcileRequest {
                     core: spec.core,
                     config: ConfigInput::Inline {
@@ -461,7 +470,16 @@ impl CoreManagerService {
                 command,
             })
             .map_err(op_error_from_control)?;
-        Ok(map_operation(handle.id(), handle.state()))
+        let admitted = map_operation(handle.id(), handle.state());
+        // After admission, and only for the submit that registered it: a
+        // rejected envelope must leave no watcher behind, and an idempotent
+        // re-submit must not add a second one to the same operation.
+        if let Some(core_type) = echoed_core
+            && handle.newly_admitted()
+        {
+            self.watch_reconcile_echo(handle, core_type);
+        }
+        Ok(admitted)
     }
 
     /// `POST /v2/core/operation`: registry query, optionally long-polling.
@@ -488,16 +506,43 @@ impl CoreManagerService {
     }
 
     /// Keeps the v1 wire-type echo truthful for v2 reconciles: committed only
-    /// when the transaction succeeds, observed from the registry rather than
-    /// assumed at admission.
-    fn watch_reconcile_echo(&self, id: OperationId, core_type: CoreType) {
+    /// when the transaction actually put that core type in place, observed
+    /// from the operation itself rather than assumed at admission.
+    ///
+    /// No bound on the wait: every operation reaches a terminal state, an
+    /// executor death included, so the watcher always ends.
+    fn watch_reconcile_echo(&self, handle: OperationHandle, core_type: CoreType) {
         let service = self.clone();
+        let sequence = handle.sequence();
         tokio::spawn(async move {
-            let bound = std::time::Duration::from_millis(MAX_OPERATION_WAIT_MS * 2);
-            if let Some(OperationState::Succeeded(_)) =
-                service.inner.control.wait_operation(id, bound).await
+            let state = match handle.wait().await {
+                Ok(output) => OperationState::Succeeded(output),
+                Err(error) => OperationState::Failed(error),
+            };
+            let commits = echo_commits(&state);
+            if !commits
+                && !matches!(
+                    state,
+                    OperationState::Succeeded(OperationOutput::Reconciled(_))
+                )
             {
+                // The transaction never reached a commit point, so it says
+                // nothing about the echo either way.
+                return;
+            }
+            let mut applied = service.inner.echo_applied.lock();
+            if applied.is_some_and(|latest| latest >= sequence) {
+                // A later reconcile already had the last word.
+                return;
+            }
+            *applied = Some(sequence);
+            if commits {
                 service.publish_requested_core(Some(&core_type));
+            } else {
+                // A rollback restored the old spec, so the echo must not claim
+                // the requested type — but the revision and state still moved,
+                // so clients need the fresh snapshot. Same rule as v1 apply.
+                service.publish_requested_core(None);
             }
         });
     }
@@ -743,6 +788,20 @@ fn map_revision_id(info: &RevisionIdInfo) -> RevisionId {
 /// keep every warning. `ApplyOutcome` is not `#[non_exhaustive]`: if the
 /// manager grows a variant, this match must fail to compile rather than
 /// silently mislabel it.
+/// Whether an operation's terminal state committed the core type it asked for.
+/// Only a reconcile can, and only one that was not rolled back:
+/// `DurabilityUncertain` wraps the real outcome and is unwrapped first.
+fn echo_commits(state: &OperationState) -> bool {
+    let OperationState::Succeeded(OperationOutput::Reconciled(outcome)) = state else {
+        return false;
+    };
+    let mut effective = outcome;
+    while let ApplyOutcome::DurabilityUncertain { outcome, .. } = effective {
+        effective = &**outcome;
+    }
+    !matches!(effective, ApplyOutcome::RolledBack { .. })
+}
+
 fn op_error_from_control(error: ControlError) -> OpError {
     match error.kind {
         Some(kind) => OpError::with_kind(kind, error.message),
@@ -1810,6 +1869,68 @@ mod tests {
         assert!(infos.health.is_none());
         assert!(infos.revision.is_none());
         assert!(infos.config_path.is_none());
+    }
+
+    /// The echo names the core type a reconcile *put in place*. Anything else
+    /// — a rollback, a non-reconcile outcome, a failure — must leave it alone.
+    #[test]
+    fn only_a_committed_reconcile_moves_the_wire_type_echo() {
+        for outcome in [
+            ApplyOutcome::Started {
+                revision: revision(1),
+            },
+            ApplyOutcome::Noop {
+                revision: revision(2),
+            },
+            ApplyOutcome::Patched {
+                revision: revision(3),
+            },
+            ApplyOutcome::Reloaded {
+                revision: revision(4),
+            },
+            ApplyOutcome::Restarted {
+                revision: revision(5),
+            },
+            ApplyOutcome::Switched {
+                revision: revision(6),
+            },
+        ] {
+            assert!(
+                super::echo_commits(&OperationState::Succeeded(OperationOutput::Reconciled(
+                    outcome.clone()
+                ))),
+                "{outcome:?} committed the requested core type"
+            );
+        }
+
+        let rolled_back = ApplyOutcome::RolledBack {
+            revision: revision(7),
+            failed_apply: "boom".to_owned(),
+        };
+        for outcome in [
+            rolled_back.clone(),
+            ApplyOutcome::DurabilityUncertain {
+                outcome: Box::new(rolled_back),
+                warning: "the parent directory was not synced".to_owned(),
+            },
+        ] {
+            assert!(!super::echo_commits(&OperationState::Succeeded(
+                OperationOutput::Reconciled(outcome)
+            )));
+        }
+
+        for output in [
+            OperationOutput::Stopped,
+            OperationOutput::Recovered,
+            OperationOutput::ShutDown,
+        ] {
+            assert!(!super::echo_commits(&OperationState::Succeeded(output)));
+        }
+        assert!(!super::echo_commits(&OperationState::Queued));
+        assert!(!super::echo_commits(&OperationState::Running));
+        assert!(!super::echo_commits(&OperationState::Failed(
+            ControlError::new(CoreErrorKind::InvalidConfig, "bad", false)
+        )));
     }
 }
 

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -8,9 +8,10 @@ use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_core_manager::{
     ApplyOutcome, ConfigInput, ConfigRevision, ControlOptions, CoreCommand, CoreCommandEnvelope,
     CoreControl, CoreError as ControlError, CoreErrorKind, CoreKind, CoreManager as Manager,
-    CoreSpec, CoreState as ManagerCoreState, CoreStatus, Error as ManagerError, HealthState,
-    HealthStatus, Host, InstanceOptions, InstanceSpec, LocalIpcPolicy, LogFrame, LogLevel,
-    ManagerOptions, OperationId, OperationOutput, OperationState, ReconcileRequest, RevisionId,
+    CoreSpec, CoreState as ManagerCoreState, CoreStatus, Error as ManagerError, ExecutorExit,
+    HealthState, HealthStatus, Host, InstanceOptions, InstanceSpec, LocalIpcPolicy, LogFrame,
+    LogLevel, ManagerOptions, OperationId, OperationOutput, OperationState, ReconcileRequest,
+    RevisionId,
 };
 use nyanpasu_ipc::api::{
     R, RBuilder,
@@ -47,6 +48,12 @@ const MAX_CONCURRENT_CHECKS: usize = 2;
 /// Long-poll clamp for `/v2/core/operation`, kept well under the route
 /// middleware's 120s liveness bound.
 const MAX_OPERATION_WAIT_MS: u64 = 90_000;
+
+/// Upper bound on the executor-first shutdown: the transaction already in
+/// flight has to finish before the queued `Shutdown` can run. Exceeding it is
+/// reported, never waited out — a leaked core is collected by the next
+/// construction's orphan sweep, a hung daemon exit is not collected by anything.
+const CORE_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
 
 /// Legacy wire strings the GUI branches on. These are protocol, not
 /// diagnostics: changing any of them is a breaking change to clash-nyanpasu.
@@ -205,6 +212,12 @@ impl CoreManagerService {
     }
 
     /// Stop the core and clean runtime artifacts. Idempotent; errors are logged, not returned.
+    ///
+    /// The stop goes through the v2 executor, which owns the closing latch:
+    /// calling the manager directly would leave the executor accepting work,
+    /// and a reconcile queued a moment earlier would put a core back up behind
+    /// the shutdown that was supposed to end it. The v1 latch below is kept
+    /// only as the v1 routing mirror it always was.
     pub async fn shutdown(&self) {
         let mut control = self.inner.control_state.lock().await;
         if control.closing {
@@ -212,9 +225,32 @@ impl CoreManagerService {
         }
         control.closing = true;
         drop(control);
-        if let Err(error) = self.inner.manager.shutdown().await {
-            tracing::error!("failed to stop the core on shutdown: {error}");
+
+        match tokio::time::timeout(CORE_SHUTDOWN_TIMEOUT, self.inner.control.shutdown()).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) if self.inner.control.executor_is_closed() => {
+                // Not a bypass: with the executor gone there is no transaction
+                // owner left, and the manager is the only remaining way to stop
+                // a core this process still owns.
+                tracing::error!(
+                    "the control executor is gone ({error}); stopping the core directly"
+                );
+                if let Err(error) = self.inner.manager.shutdown().await {
+                    tracing::error!("failed to stop the core on shutdown: {error}");
+                }
+            }
+            Ok(Err(error)) => tracing::error!("failed to stop the core on shutdown: {error}"),
+            Err(_) => tracing::error!(
+                "the core did not shut down within {CORE_SHUTDOWN_TIMEOUT:?}; \
+                 leaving it to the next orphan sweep"
+            ),
         }
+    }
+
+    /// Resolves when the v2 control executor exits, so the daemon can refuse to
+    /// keep serving a control plane that is no longer there.
+    pub async fn until_control_closed(&self) -> ExecutorExit {
+        self.inner.control.until_closed().await
     }
 
     #[instrument(skip(self, infos))]

--- a/crates/nyanpasu-service-runtime/src/server/mod.rs
+++ b/crates/nyanpasu-service-runtime/src/server/mod.rs
@@ -10,7 +10,7 @@ use consts::RuntimeInfos;
 pub use events::EventHub;
 pub use logger::Logger;
 pub use manager_bridge::CoreManagerService as CoreManager;
-use nyanpasu_core_manager::LocalIpcPolicy;
+use nyanpasu_core_manager::{ExecutorExit, LocalIpcPolicy};
 use nyanpasu_ipc::{SERVICE_PLACEHOLDER, server::create_server};
 use routing::{AppState, create_router};
 use tokio_util::sync::CancellationToken;
@@ -66,13 +66,35 @@ pub async fn run(
         }
         _ = token.cancelled() => {
             core_manager.shutdown().await;
-            match tokio::time::timeout(SERVER_DRAIN_TIMEOUT, &mut server).await {
-                Ok(result) => result?,
-                Err(_) => tracing::warn!(
-                    "pipe server did not drain within {SERVER_DRAIN_TIMEOUT:?}; abandoning open connections"
-                ),
-            }
+            drain(&mut server).await?;
         }
+        // The control plane owns every core transaction. If its executor is
+        // gone the daemon cannot serve `/v2/core/*` truthfully, so it stops
+        // rather than answering with a control plane that is not there.
+        exit = core_manager.until_control_closed() => {
+            if exit == ExecutorExit::Died {
+                tracing::error!("the core control executor died; shutting the service down");
+                core_manager.shutdown().await;
+                drain(&mut server).await?;
+                anyhow::bail!("the core control executor died");
+            }
+            // Clean: a local shutdown already ran. Nothing maps `Shutdown` onto
+            // the wire, so this is the service's own teardown finishing.
+            core_manager.shutdown().await;
+            drain(&mut server).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn drain<E: std::error::Error + Send + Sync + 'static>(
+    server: impl std::future::Future<Output = Result<(), E>> + Unpin,
+) -> Result<(), anyhow::Error> {
+    match tokio::time::timeout(SERVER_DRAIN_TIMEOUT, server).await {
+        Ok(result) => result?,
+        Err(_) => tracing::warn!(
+            "pipe server did not drain within {SERVER_DRAIN_TIMEOUT:?}; abandoning open connections"
+        ),
     }
     Ok(())
 }

--- a/crates/nyanpasu-service-runtime/src/server/mod.rs
+++ b/crates/nyanpasu-service-runtime/src/server/mod.rs
@@ -29,7 +29,9 @@ pub async fn run(
     let runtime_dir =
         camino::Utf8PathBuf::from_path_buf(crate::utils::dirs::service_core_runtime_dir())
             .map_err(|path| anyhow::anyhow!("core runtime dir is not UTF-8: {}", path.display()))?;
-    let core_manager = CoreManager::new(runtime_dir, local_ipc_policy).await?;
+    let data_dir = camino::Utf8PathBuf::from_path_buf(runtime.nyanpasu_data_dir.clone())
+        .map_err(|path| anyhow::anyhow!("nyanpasu data dir is not UTF-8: {}", path.display()))?;
+    let core_manager = CoreManager::new(runtime_dir, local_ipc_policy, data_dir).await?;
     let hub = EventHub::new();
     core_manager.spawn_bridges(hub.clone());
 

--- a/crates/nyanpasu-service-runtime/src/server/routing/core/mod.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/core/mod.rs
@@ -1,6 +1,9 @@
 use axum::Router;
 use nyanpasu_ipc::{
-    api::contract::{CoreApply, CoreCheck, CoreRecover, CoreRestart, CoreStart, CoreStop},
+    api::contract::{
+        CoreApply, CoreCheck, CoreRecover, CoreRestart, CoreStart, CoreStop, CoreV2Operation,
+        CoreV2Status, CoreV2Submit,
+    },
     server::RegisterOperation,
 };
 
@@ -12,6 +15,7 @@ pub mod recover;
 pub mod restart;
 pub mod start;
 pub mod stop;
+pub mod v2;
 
 pub fn setup() -> Router<AppState> {
     Router::new()
@@ -21,4 +25,7 @@ pub fn setup() -> Router<AppState> {
         .register(CoreApply, apply::apply)
         .register(CoreCheck, check::check)
         .register(CoreRecover, recover::recover)
+        .register(CoreV2Submit, v2::submit)
+        .register(CoreV2Operation, v2::operation)
+        .register(CoreV2Status, v2::status)
 }

--- a/crates/nyanpasu-service-runtime/src/server/routing/core/v2.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/core/v2.rs
@@ -1,0 +1,42 @@
+//! The v2 control-plane routes: thin adapters over the bridge's submit /
+//! operation / status methods. Additive next to the v1 routes.
+
+use axum::{Json, extract::State, http::StatusCode};
+use nyanpasu_ipc::api::{
+    R, RBuilder,
+    core::v2::{CoreOperationReq, CoreOperationRes, CoreSubmitReq, CoreSubmitRes},
+    status::CoreInfos,
+};
+
+use crate::server::routing::AppState;
+
+pub async fn submit(
+    State(state): State<AppState>,
+    Json(payload): Json<CoreSubmitReq<'_>>,
+) -> (StatusCode, Json<CoreSubmitRes<'static>>) {
+    match state.core_manager.submit_v2(&state.runtime, &payload) {
+        Ok(info) => (StatusCode::OK, Json(RBuilder::success(info))),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(error.into_envelope()),
+        ),
+    }
+}
+
+pub async fn operation(
+    State(state): State<AppState>,
+    Json(payload): Json<CoreOperationReq<'_>>,
+) -> (StatusCode, Json<CoreOperationRes<'static>>) {
+    match state.core_manager.operation_v2(&payload).await {
+        Ok(info) => (StatusCode::OK, Json(RBuilder::success(info))),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(error.into_envelope()),
+        ),
+    }
+}
+
+pub async fn status(State(state): State<AppState>) -> (StatusCode, Json<R<'static, CoreInfos>>) {
+    let infos = state.core_manager.status().await;
+    (StatusCode::OK, Json(RBuilder::success(infos)))
+}

--- a/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
@@ -550,7 +550,7 @@ async fn v2_submit_stop_runs_to_a_classified_terminal_failure() {
         CoreOperationRes, CoreSubmitReq, CoreSubmitRes, OperationPhase,
     };
     let env = TestEnv::new().await;
-    let id = "00112233445566778899aabbccddeeff";
+    let id = "0011223344556677-8899aabb-ccddeeff";
     let response = post_json(
         env.state.clone(),
         CORE_V2_SUBMIT_ENDPOINT,
@@ -594,7 +594,7 @@ async fn v2_submit_reuses_of_an_id_with_a_different_payload_conflict() {
         CORE_V2_SUBMIT_ENDPOINT, CoreCommandInfo, CoreSubmitReq, CoreSubmitRes,
     };
     let env = TestEnv::new().await;
-    let id = "00112233445566778899aabbccddeeff";
+    let id = "0011223344556677-8899aabb-ccddeeff";
     let response = post_json(
         env.state.clone(),
         CORE_V2_SUBMIT_ENDPOINT,
@@ -647,7 +647,7 @@ async fn v2_operation_rejects_malformed_and_unknown_ids() {
         env.state.clone(),
         CORE_V2_OPERATION_ENDPOINT,
         &CoreOperationReq {
-            operation_id: Cow::Borrowed("ffeeddccbbaa99887766554433221100"),
+            operation_id: Cow::Borrowed("ffeeddccbbaa9988-77665544-33221100"),
             wait_ms: None,
         },
     )

--- a/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
@@ -680,3 +680,29 @@ async fn v2_status_serves_the_canonical_projection() {
     assert!(matches!(infos.state, CoreState::Stopped(_)));
     assert!(infos.r#type.is_none(), "no core was ever requested");
 }
+
+/// Daemon shutdown used to call the manager directly, which left the v2
+/// control plane wide open: a submit that landed a moment later was admitted
+/// and ran a core transaction after the daemon had already stopped its core.
+#[tokio::test]
+async fn shutdown_closes_the_v2_control_plane_to_new_work() {
+    use nyanpasu_ipc::api::core::v2::{
+        CORE_V2_SUBMIT_ENDPOINT, CoreCommandInfo, CoreSubmitReq, CoreSubmitRes,
+    };
+    let env = TestEnv::new().await;
+    env.state.core_manager.shutdown().await;
+
+    let response = post_json(
+        env.state.clone(),
+        CORE_V2_SUBMIT_ENDPOINT,
+        &CoreSubmitReq {
+            operation_id: Cow::Borrowed("0011223344556677-8899aabb-ccddeeff"),
+            command: CoreCommandInfo::Stop,
+        },
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let envelope: CoreSubmitRes<'static> = body_of(response).await;
+    assert_eq!(envelope.code, ResponseCode::OtherError);
+    assert_eq!(envelope.error_kind.as_deref(), Some("shutting_down"));
+}

--- a/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
@@ -620,6 +620,9 @@ async fn v2_submit_reuses_of_an_id_with_a_different_payload_conflict() {
     let second: CoreSubmitRes<'static> = body_of(response).await;
     assert_eq!(second.code, ResponseCode::OtherError);
     assert_eq!(second.error_kind.as_deref(), Some("operation_conflict"));
+    // Retrying a conflict re-submits the same losing payload, so the answer is
+    // an explicit `false` rather than an absent field the caller has to guess at.
+    assert_eq!(second.retryable, Some(false));
 }
 
 /// A malformed id and an unknown id both come back as error envelopes, and
@@ -705,4 +708,5 @@ async fn shutdown_closes_the_v2_control_plane_to_new_work() {
     let envelope: CoreSubmitRes<'static> = body_of(response).await;
     assert_eq!(envelope.code, ResponseCode::OtherError);
     assert_eq!(envelope.error_kind.as_deref(), Some("shutting_down"));
+    assert_eq!(envelope.retryable, Some(false));
 }

--- a/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
@@ -46,7 +46,9 @@ impl TestEnv {
         let root = dir.path();
         let runtime_dir =
             Utf8PathBuf::from_path_buf(root.join("core-runtime")).expect("temp path is UTF-8");
-        let core_manager = CoreManager::new(runtime_dir, LocalIpcPolicy::Disable)
+        let data_dir =
+            Utf8PathBuf::from_path_buf(root.join("nyanpasu-data")).expect("temp path is UTF-8");
+        let core_manager = CoreManager::new(runtime_dir, LocalIpcPolicy::Disable, data_dir)
             .await
             .unwrap();
         let runtime = Arc::new(RuntimeInfos {
@@ -536,4 +538,145 @@ async fn the_status_response_reports_the_log_directories() {
         core_dir.ends_with("logs"),
         "core log dir should be the manager's archive: {core_dir:?}"
     );
+}
+
+/// The full v2 submit -> long-poll path over the wire, on a stopped manager:
+/// admission succeeds, the transaction runs to its own classified failure,
+/// and the caller reads it back from the registry.
+#[tokio::test]
+async fn v2_submit_stop_runs_to_a_classified_terminal_failure() {
+    use nyanpasu_ipc::api::core::v2::{
+        CORE_V2_OPERATION_ENDPOINT, CORE_V2_SUBMIT_ENDPOINT, CoreCommandInfo, CoreOperationReq,
+        CoreOperationRes, CoreSubmitReq, CoreSubmitRes, OperationPhase,
+    };
+    let env = TestEnv::new().await;
+    let id = "00112233445566778899aabbccddeeff";
+    let response = post_json(
+        env.state.clone(),
+        CORE_V2_SUBMIT_ENDPOINT,
+        &CoreSubmitReq {
+            operation_id: Cow::Borrowed(id),
+            command: CoreCommandInfo::Stop,
+        },
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let envelope: CoreSubmitRes<'static> = body_of(response).await;
+    assert_eq!(envelope.code, ResponseCode::Ok);
+    let info = envelope
+        .data
+        .expect("submit returns the admission snapshot");
+    assert_eq!(info.id, id);
+
+    let response = post_json(
+        env.state.clone(),
+        CORE_V2_OPERATION_ENDPOINT,
+        &CoreOperationReq {
+            operation_id: Cow::Borrowed(id),
+            wait_ms: Some(5_000),
+        },
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let envelope: CoreOperationRes<'static> = body_of(response).await;
+    let info = envelope.data.expect("query returns the operation");
+    assert_eq!(info.phase, OperationPhase::Failed);
+    let error = info.error.expect("a failed operation carries its error");
+    assert_eq!(error.kind.as_deref(), Some("not_started"));
+    assert!(!error.retryable);
+}
+
+/// Same id, different payload: the idempotency registry refuses at admission,
+/// through the wire, with the pinned kind.
+#[tokio::test]
+async fn v2_submit_reuses_of_an_id_with_a_different_payload_conflict() {
+    use nyanpasu_ipc::api::core::v2::{
+        CORE_V2_SUBMIT_ENDPOINT, CoreCommandInfo, CoreSubmitReq, CoreSubmitRes,
+    };
+    let env = TestEnv::new().await;
+    let id = "00112233445566778899aabbccddeeff";
+    let response = post_json(
+        env.state.clone(),
+        CORE_V2_SUBMIT_ENDPOINT,
+        &CoreSubmitReq {
+            operation_id: Cow::Borrowed(id),
+            command: CoreCommandInfo::Stop,
+        },
+    )
+    .await;
+    let first: CoreSubmitRes<'static> = body_of(response).await;
+    assert_eq!(first.code, ResponseCode::Ok);
+
+    let response = post_json(
+        env.state.clone(),
+        CORE_V2_SUBMIT_ENDPOINT,
+        &CoreSubmitReq {
+            operation_id: Cow::Borrowed(id),
+            command: CoreCommandInfo::Recover,
+        },
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let second: CoreSubmitRes<'static> = body_of(response).await;
+    assert_eq!(second.code, ResponseCode::OtherError);
+    assert_eq!(second.error_kind.as_deref(), Some("operation_conflict"));
+}
+
+/// A malformed id and an unknown id both come back as error envelopes, and
+/// the unknown one points the caller at the recovery contract (status + CAS).
+#[tokio::test]
+async fn v2_operation_rejects_malformed_and_unknown_ids() {
+    use nyanpasu_ipc::api::core::v2::{
+        CORE_V2_OPERATION_ENDPOINT, CoreOperationReq, CoreOperationRes,
+    };
+    let env = TestEnv::new().await;
+    let response = post_json(
+        env.state.clone(),
+        CORE_V2_OPERATION_ENDPOINT,
+        &CoreOperationReq {
+            operation_id: Cow::Borrowed("not-hex"),
+            wait_ms: None,
+        },
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let envelope: CoreOperationRes<'static> = body_of(response).await;
+    assert!(envelope.msg.contains("malformed operation id"));
+
+    let response = post_json(
+        env.state.clone(),
+        CORE_V2_OPERATION_ENDPOINT,
+        &CoreOperationReq {
+            operation_id: Cow::Borrowed("ffeeddccbbaa99887766554433221100"),
+            wait_ms: None,
+        },
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let envelope: CoreOperationRes<'static> = body_of(response).await;
+    assert!(envelope.msg.contains("unknown operation"));
+}
+
+/// `/v2/core/status` serves the canonical projection without touching the
+/// runtime.
+#[tokio::test]
+async fn v2_status_serves_the_canonical_projection() {
+    use nyanpasu_ipc::api::core::v2::CORE_V2_STATUS_ENDPOINT;
+    let env = TestEnv::new().await;
+    let response = create_router(env.state.clone())
+        .oneshot(
+            Request::builder()
+                .uri(CORE_V2_STATUS_ENDPOINT)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let envelope: nyanpasu_ipc::api::R<'static, nyanpasu_ipc::api::status::CoreInfos> =
+        body_of(response).await;
+    assert_eq!(envelope.code, ResponseCode::Ok);
+    let infos = envelope.data.expect("status always has a body");
+    assert!(matches!(infos.state, CoreState::Stopped(_)));
+    assert!(infos.r#type.is_none(), "no core was ever requested");
 }

--- a/nyanpasu_ipc/src/api/contract.rs
+++ b/nyanpasu_ipc/src/api/contract.rs
@@ -27,6 +27,10 @@ use super::{
         restart::CORE_RESTART_ENDPOINT,
         start::CORE_START_ENDPOINT,
         stop::CORE_STOP_ENDPOINT,
+        v2::{
+            CORE_V2_OPERATION_ENDPOINT, CORE_V2_STATUS_ENDPOINT, CORE_V2_SUBMIT_ENDPOINT,
+            OperationInfo,
+        },
     },
     log::{LOGS_INSPECT_ENDPOINT, LOGS_RETRIEVE_ENDPOINT, LogsResBody},
     network::set_dns::{NETWORK_SET_DNS_ENDPOINT, NetworkSetDnsReq},
@@ -139,6 +143,36 @@ impl IpcOperation for LogsInspect {
     type Data = LogsResBody<'static>;
 }
 
+/// `POST /v2/core/submit`
+pub struct CoreV2Submit;
+
+impl IpcOperation for CoreV2Submit {
+    const METHOD: Method = Method::POST;
+    const PATH: &'static str = CORE_V2_SUBMIT_ENDPOINT;
+    type Req<'a> = super::core::v2::CoreSubmitReq<'a>;
+    type Data = OperationInfo;
+}
+
+/// `POST /v2/core/operation`
+pub struct CoreV2Operation;
+
+impl IpcOperation for CoreV2Operation {
+    const METHOD: Method = Method::POST;
+    const PATH: &'static str = CORE_V2_OPERATION_ENDPOINT;
+    type Req<'a> = super::core::v2::CoreOperationReq<'a>;
+    type Data = OperationInfo;
+}
+
+/// `GET /v2/core/status`
+pub struct CoreV2Status;
+
+impl IpcOperation for CoreV2Status {
+    const METHOD: Method = Method::GET;
+    const PATH: &'static str = CORE_V2_STATUS_ENDPOINT;
+    type Req<'a> = ();
+    type Data = super::status::CoreInfos;
+}
+
 /// `POST /network/set_dns`
 pub struct NetworkSetDns;
 
@@ -182,6 +216,23 @@ mod tests {
         assert_eq!(
             (NetworkSetDns::METHOD, NetworkSetDns::PATH),
             (Method::POST, "/network/set_dns")
+        );
+    }
+
+    /// The v2 control-plane endpoints, pinned for the same reason.
+    #[test]
+    fn every_v2_operation_keeps_its_declared_address() {
+        assert_eq!(
+            (CoreV2Submit::METHOD, CoreV2Submit::PATH),
+            (Method::POST, "/v2/core/submit")
+        );
+        assert_eq!(
+            (CoreV2Operation::METHOD, CoreV2Operation::PATH),
+            (Method::POST, "/v2/core/operation")
+        );
+        assert_eq!(
+            (CoreV2Status::METHOD, CoreV2Status::PATH),
+            (Method::GET, "/v2/core/status")
         );
     }
 

--- a/nyanpasu_ipc/src/api/core/mod.rs
+++ b/nyanpasu_ipc/src/api/core/mod.rs
@@ -4,3 +4,4 @@ pub mod recover;
 pub mod restart;
 pub mod start;
 pub mod stop;
+pub mod v2;

--- a/nyanpasu_ipc/src/api/core/v2.rs
+++ b/nyanpasu_ipc/src/api/core/v2.rs
@@ -1,0 +1,250 @@
+//! The v2 control-plane wire: submit / operation query / status. Additive —
+//! every v1 endpoint stays untouched until the app-side switch (the bridge
+//! stage) deletes them.
+//!
+//! Deliberate absences:
+//!
+//! - No shutdown command: the daemon's own lifecycle belongs to the OS
+//!   service layer, never to the core wire.
+//! - No caller paths: the caller ships the config *bytes*; the daemon
+//!   materializes them itself (design §16.2).
+//! - No check command: the advisory check keeps its v1 endpoint until the
+//!   bridge stage; it is not a mutating operation and gains nothing from the
+//!   submit envelope.
+
+use std::borrow::Cow;
+
+use serde::{Deserialize, Serialize};
+
+use crate::api::{
+    R,
+    status::{ConfigRevisionInfo, RevisionIdInfo},
+};
+
+pub const CORE_V2_SUBMIT_ENDPOINT: &str = "/v2/core/submit";
+pub const CORE_V2_OPERATION_ENDPOINT: &str = "/v2/core/operation";
+pub const CORE_V2_STATUS_ENDPOINT: &str = "/v2/core/status";
+
+/// Submit one mutating operation. The reply is the operation's registry
+/// snapshot at admission time — usually `queued` — not its result; poll or
+/// long-poll [`CoreOperationReq`] for that.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct CoreSubmitReq<'n> {
+    /// 32 lowercase hex characters: the idempotency identity. The same id
+    /// with the same payload attaches to the original operation; the same id
+    /// with a different payload fails with `error_kind =
+    /// "operation_conflict"`.
+    pub operation_id: Cow<'n, str>,
+    pub command: CoreCommandInfo<'n>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CoreCommandInfo<'n> {
+    /// The single mutating convergence command: make the runtime match this
+    /// core + config. Start, patch, reload, restart, and switch are derived
+    /// inside the transaction, never chosen by the caller — and the config
+    /// check runs inside it too (a rejection is a clean abort with
+    /// `error_kind = "invalid_config"` or `"config_check_failed"`).
+    Reconcile {
+        core_type: Cow<'n, nyanpasu_utils::core::CoreType>,
+        /// The full config document, as text. Never a path.
+        config: Cow<'n, str>,
+        /// FNV-1a hex digest of `config` as the caller computed it; verified
+        /// on receipt when present.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        expected_digest: Option<Cow<'n, str>>,
+        /// Compare-and-swap token: the revision the caller believes is
+        /// applied. `None` reconciles unconditionally; a mismatch changes
+        /// nothing and fails with `error_kind = "revision_conflict"`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        expected_applied: Option<RevisionIdInfo>,
+    },
+    Stop,
+    Recover,
+}
+
+/// Query one operation, optionally long-polling for its terminal state.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct CoreOperationReq<'n> {
+    pub operation_id: Cow<'n, str>,
+    /// Long-poll bound in milliseconds: the reply returns the moment the
+    /// operation reaches a terminal state, or with its current state when the
+    /// bound (server-clamped) elapses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wait_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(rename_all = "snake_case")]
+pub enum OperationPhase {
+    Queued,
+    Running,
+    Succeeded,
+    Failed,
+}
+
+/// How a reconcile transaction carried the change. `RolledBack` is a
+/// *successfully completed* transaction whose desired config did not take
+/// effect; `revision` is then the one actually running.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(rename_all = "snake_case")]
+pub enum ReconcileOutcomeKind {
+    /// Nothing was running; the desired runtime was started cold.
+    Started,
+    Noop,
+    Patched,
+    Reloaded,
+    Restarted,
+    Switched,
+    RolledBack,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct ReconcileOutcomeInfo {
+    pub outcome: ReconcileOutcomeKind,
+    /// The revision the core is running now.
+    pub revision: ConfigRevisionInfo,
+    /// Durability or degradation warnings the transaction survived.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub warning: Option<String>,
+    /// Why the desired config was rejected; set only for `RolledBack`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failed_apply: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum OperationOutputInfo {
+    Reconciled(ReconcileOutcomeInfo),
+    Stopped,
+    Recovered,
+    /// Never produced through this wire (there is no shutdown command); kept
+    /// so a locally submitted shutdown observed through the registry decodes.
+    ShutDown,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct OperationErrorInfo {
+    /// The wire spelling of the [`CoreErrorKind`](crate::api::CoreErrorKind)
+    /// classification, absent when the failure is unclassified — never
+    /// guessed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<Cow<'static, str>>,
+    pub message: String,
+    /// Whether resubmitting the same envelope can plausibly succeed.
+    pub retryable: bool,
+}
+
+/// One operation as the registry sees it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct OperationInfo {
+    pub id: String,
+    pub phase: OperationPhase,
+    /// Present exactly when `phase == succeeded`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output: Option<OperationOutputInfo>,
+    /// Present exactly when `phase == failed`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<OperationErrorInfo>,
+}
+
+pub type CoreSubmitRes<'a> = R<'a, OperationInfo>;
+pub type CoreOperationRes<'a> = R<'a, OperationInfo>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_reconcile_submit_roundtrips_with_every_optional_present() {
+        let request = CoreSubmitReq {
+            operation_id: Cow::Borrowed("00112233445566778899aabbccddeeff"),
+            command: CoreCommandInfo::Reconcile {
+                core_type: Cow::Owned(nyanpasu_utils::core::CoreType::Clash(
+                    nyanpasu_utils::core::ClashCoreType::Mihomo,
+                )),
+                config: Cow::Borrowed("external-controller: 127.0.0.1:9090\n"),
+                expected_digest: Some(Cow::Borrowed("cbf29ce484222325")),
+                expected_applied: Some(RevisionIdInfo {
+                    epoch: 3,
+                    generation: 7,
+                    effective_hash: "fedcba9876543210".into(),
+                }),
+            },
+        };
+        let encoded = serde_json::to_string(&request).unwrap();
+        assert!(encoded.contains("\"type\":\"reconcile\""));
+        let decoded: CoreSubmitReq<'_> = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded.operation_id, request.operation_id);
+        assert!(matches!(decoded.command, CoreCommandInfo::Reconcile { .. }));
+    }
+
+    #[test]
+    fn bare_commands_and_optionals_stay_off_the_wire() {
+        let request = CoreSubmitReq {
+            operation_id: Cow::Borrowed("00112233445566778899aabbccddeeff"),
+            command: CoreCommandInfo::Stop,
+        };
+        let encoded = serde_json::to_string(&request).unwrap();
+        assert!(encoded.contains("\"type\":\"stop\""));
+        assert!(!encoded.contains("expected_digest"));
+
+        let query = CoreOperationReq {
+            operation_id: Cow::Borrowed("00112233445566778899aabbccddeeff"),
+            wait_ms: None,
+        };
+        assert!(!serde_json::to_string(&query).unwrap().contains("wait_ms"));
+    }
+
+    #[test]
+    fn operation_info_roundtrips_in_both_terminal_shapes() {
+        let succeeded = OperationInfo {
+            id: "00112233445566778899aabbccddeeff".into(),
+            phase: OperationPhase::Succeeded,
+            output: Some(OperationOutputInfo::Reconciled(ReconcileOutcomeInfo {
+                outcome: ReconcileOutcomeKind::Started,
+                revision: ConfigRevisionInfo {
+                    epoch: 1,
+                    generation: 1,
+                    source_hash: "0123456789abcdef".into(),
+                    effective_hash: "fedcba9876543210".into(),
+                },
+                warning: None,
+                failed_apply: None,
+            })),
+            error: None,
+        };
+        let encoded = serde_json::to_string(&succeeded).unwrap();
+        assert!(encoded.contains("\"outcome\":\"started\""));
+        assert_eq!(
+            serde_json::from_str::<OperationInfo>(&encoded).unwrap(),
+            succeeded
+        );
+
+        let failed = OperationInfo {
+            id: "00112233445566778899aabbccddeeff".into(),
+            phase: OperationPhase::Failed,
+            output: None,
+            error: Some(OperationErrorInfo {
+                kind: Some(Cow::Borrowed("quarantined")),
+                message: "manager is quarantined".into(),
+                retryable: false,
+            }),
+        };
+        let encoded = serde_json::to_string(&failed).unwrap();
+        assert_eq!(
+            serde_json::from_str::<OperationInfo>(&encoded).unwrap(),
+            failed
+        );
+    }
+}

--- a/nyanpasu_ipc/src/api/mod.rs
+++ b/nyanpasu_ipc/src/api/mod.rs
@@ -55,6 +55,13 @@ pub struct R<'a, T: Serialize + DeserializeOwned + Debug> {
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error_kind: Option<Cow<'a, str>>,
+    /// Whether retrying the same request could succeed. Absent means the
+    /// service did not say — never "no": a caller that needs a decision here
+    /// must fall back to [`CoreErrorKind::default_retryable`], because an older
+    /// service omits the field entirely.
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
 }
 
 impl<T: Serialize + DeserializeOwned + Debug> R<'_, T> {
@@ -100,6 +107,7 @@ impl<'a, T: Serialize + DeserializeOwned + Debug> RBuilder<'a, T> {
             data: None,
             ts: crate::utils::get_current_ts(),
             error_kind: None,
+            retryable: None,
         }
     }
 
@@ -108,8 +116,13 @@ impl<'a, T: Serialize + DeserializeOwned + Debug> RBuilder<'a, T> {
     /// `kind` is `Option` because a failure the service cannot classify must
     /// still be reportable — guessing a kind is worse than omitting it. Taking
     /// the enum rather than a string is what keeps a hand-typed kind off the
-    /// wire.
-    pub fn other_error_with_kind(msg: Cow<'a, str>, kind: Option<CoreErrorKind>) -> R<'a, T> {
+    /// wire. `retryable` is `Option` for the same reason, and is the producer's
+    /// answer rather than the kind's default when both exist.
+    pub fn other_error_with_kind(
+        msg: Cow<'a, str>,
+        kind: Option<CoreErrorKind>,
+        retryable: Option<bool>,
+    ) -> R<'a, T> {
         let code = ResponseCode::OtherError;
         R {
             code,
@@ -117,6 +130,7 @@ impl<'a, T: Serialize + DeserializeOwned + Debug> RBuilder<'a, T> {
             data: None,
             ts: crate::utils::get_current_ts(),
             error_kind: kind.map(|kind| Cow::Borrowed(kind.as_str())),
+            retryable,
         }
     }
 
@@ -128,6 +142,7 @@ impl<'a, T: Serialize + DeserializeOwned + Debug> RBuilder<'a, T> {
             data: Some(data),
             ts: crate::utils::get_current_ts(),
             error_kind: None,
+            retryable: None,
         }
     }
 }

--- a/nyanpasu_ipc/src/client/mod.rs
+++ b/nyanpasu_ipc/src/client/mod.rs
@@ -51,6 +51,10 @@ pub enum ClientError {
         /// The envelope's `error_kind`, when the service classified the
         /// failure. See [`crate::api::CoreErrorKind`].
         error_kind: Option<String>,
+        /// The envelope's `retryable`, when the service answered. `None` also
+        /// covers every service too old to carry the field, so it must not be
+        /// read as "do not retry"; see [`ClientError::retryable`].
+        retryable: Option<bool>,
     },
     #[error("IPC request `{operation}` succeeded but carried no data")]
     EmptyData { operation: &'static str },
@@ -77,6 +81,21 @@ impl ClientError {
                 error_kind.as_deref().and_then(CoreErrorKind::from_wire)
             }
             _ => None,
+        }
+    }
+
+    /// Whether retrying this request could succeed.
+    ///
+    /// The service's own answer wins; when it did not give one — an older
+    /// build, or an unclassified failure — the kind's default stands in, and a
+    /// failure with neither is not retryable.
+    pub fn retryable(&self) -> bool {
+        match self {
+            Self::Server { retryable, .. } => retryable.unwrap_or_else(|| {
+                self.core_error_kind()
+                    .is_some_and(|kind| kind.default_retryable())
+            }),
+            _ => false,
         }
     }
 }
@@ -159,6 +178,7 @@ impl Client {
                 code: envelope.code,
                 msg: envelope.msg.into_owned(),
                 error_kind: envelope.error_kind.map(|kind| kind.into_owned()),
+                retryable: envelope.retryable,
             });
         }
         let body =
@@ -204,6 +224,7 @@ impl Client {
                 code: envelope.code,
                 msg: envelope.msg.into_owned(),
                 error_kind: envelope.error_kind.map(|kind| kind.into_owned()),
+                retryable: envelope.retryable,
             });
         }
         Ok(envelope)
@@ -220,6 +241,7 @@ mod tests {
             operation: "/core/apply",
             code: ResponseCode::OtherError,
             msg: "boom".into(),
+            retryable: None,
             error_kind: Some("revision_conflict".into()),
         };
         assert_eq!(
@@ -228,12 +250,28 @@ mod tests {
         );
     }
 
+    /// The kind's default is a fallback for services that did not answer, not
+    /// a rule that overrides one that did.
+    #[test]
+    fn the_services_own_retryability_wins_over_the_kind_default() {
+        let server = |retryable| ClientError::Server {
+            operation: "/core/v2/submit",
+            code: ResponseCode::OtherError,
+            msg: "boom".into(),
+            retryable,
+            error_kind: Some("backend_unavailable".into()),
+        };
+        assert!(server(None).retryable());
+        assert!(!server(Some(false)).retryable());
+    }
+
     #[test]
     fn an_unknown_kind_keeps_its_raw_string() {
         let error = ClientError::Server {
             operation: "/core/apply",
             code: ResponseCode::OtherError,
             msg: "boom".into(),
+            retryable: None,
             error_kind: Some("a_future_kind".into()),
         };
         assert!(error.core_error_kind().is_none());

--- a/nyanpasu_ipc/src/client/shortcuts.rs
+++ b/nyanpasu_ipc/src/client/shortcuts.rs
@@ -9,10 +9,16 @@ use reqwest_websocket::{Message, Upgrade};
 use crate::api::{
     self,
     contract::{
-        CoreApply, CoreCheck, CoreRecover, CoreRestart, CoreStart, CoreStop, LogsInspect,
-        LogsRetrieve, NetworkSetDns, Status,
+        CoreApply, CoreCheck, CoreRecover, CoreRestart, CoreStart, CoreStop, CoreV2Operation,
+        CoreV2Status, CoreV2Submit, LogsInspect, LogsRetrieve, NetworkSetDns, Status,
     },
-    core::apply::{CORE_APPLY_ENDPOINT, CoreApplyData},
+    core::{
+        apply::{CORE_APPLY_ENDPOINT, CoreApplyData},
+        v2::{
+            CORE_V2_OPERATION_ENDPOINT, CORE_V2_STATUS_ENDPOINT, CORE_V2_SUBMIT_ENDPOINT,
+            OperationInfo,
+        },
+    },
     log::{LOGS_INSPECT_ENDPOINT, LOGS_RETRIEVE_ENDPOINT},
     status::STATUS_ENDPOINT,
     ws::events::{EVENT_URI, Event},
@@ -63,6 +69,43 @@ impl Client {
     /// Dry-run a config against a core binary without touching the running one.
     pub async fn check_config(&self, payload: &api::core::check::CoreCheckReq<'_>) -> Result<()> {
         self.call::<CoreCheck>(Some(payload)).await.map(|_| ())
+    }
+
+    /// Submit one v2 control-plane operation. The reply is the operation's
+    /// admission-time snapshot; poll [`Self::core_operation`] for the result.
+    pub async fn submit_core(
+        &self,
+        payload: &api::core::v2::CoreSubmitReq<'_>,
+    ) -> Result<OperationInfo> {
+        self.call::<CoreV2Submit>(Some(payload))
+            .await?
+            .data
+            .ok_or(ClientError::EmptyData {
+                operation: CORE_V2_SUBMIT_ENDPOINT,
+            })
+    }
+
+    /// Query one v2 operation, optionally long-polling for its terminal state.
+    pub async fn core_operation(
+        &self,
+        payload: &api::core::v2::CoreOperationReq<'_>,
+    ) -> Result<OperationInfo> {
+        self.call::<CoreV2Operation>(Some(payload))
+            .await?
+            .data
+            .ok_or(ClientError::EmptyData {
+                operation: CORE_V2_OPERATION_ENDPOINT,
+            })
+    }
+
+    /// The daemon's canonical core status projection.
+    pub async fn core_status_v2(&self) -> Result<api::status::CoreInfos> {
+        self.call::<CoreV2Status>(None)
+            .await?
+            .data
+            .ok_or(ClientError::EmptyData {
+                operation: CORE_V2_STATUS_ENDPOINT,
+            })
     }
 
     /// Clear the manager's quarantine latch. Idempotent.

--- a/nyanpasu_ipc/tests/roundtrip.rs
+++ b/nyanpasu_ipc/tests/roundtrip.rs
@@ -401,6 +401,7 @@ async fn apply_config_conflict_handler() -> (StatusCode, Json<CoreApplyRes<'stat
         Json(RBuilder::other_error_with_kind(
             Cow::Borrowed("config revision conflict"),
             Some(CoreErrorKind::RevisionConflict),
+            None,
         )),
     )
 }
@@ -747,6 +748,56 @@ async fn apply_config_roundtrip() {
 
     let _ = shutdown.send(());
     cleanup(&placeholder);
+}
+
+/// The control plane decides retryability per failure, not per kind, so the
+/// answer has to survive the wire in both polarities — including `false`, which
+/// an absent field would silently impersonate.
+#[tokio::test]
+async fn v2_server_error_roundtrips_kind_and_retryability() {
+    for (index, (kind, retryable)) in [
+        (CoreErrorKind::QueueFull, true),
+        (CoreErrorKind::OperationConflict, false),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let placeholder = format!("nyanpasu-ipc-test-{}-retry{index}", std::process::id());
+        let router = Router::new()
+            .route(STATUS_ENDPOINT, get(status_handler))
+            .route(
+                CORE_APPLY_ENDPOINT,
+                post(move || async move {
+                    let envelope: CoreApplyRes<'static> = RBuilder::other_error_with_kind(
+                        Cow::Borrowed("classified failure"),
+                        Some(kind),
+                        Some(retryable),
+                    );
+                    (StatusCode::INTERNAL_SERVER_ERROR, Json(envelope))
+                }),
+            );
+        let Some((shutdown, client)) = run_server(&placeholder, router).await else {
+            return;
+        };
+
+        let error = client.apply_config(&apply_payload()).await.unwrap_err();
+        assert_eq!(error.core_error_kind(), Some(kind));
+        assert_eq!(error.retryable(), retryable);
+        match error {
+            ClientError::Server {
+                error_kind,
+                retryable: wire,
+                ..
+            } => {
+                assert_eq!(error_kind.as_deref(), Some(kind.as_str()));
+                assert_eq!(wire, Some(retryable));
+            }
+            other => panic!("expected a classified server error, got: {other:?}"),
+        }
+
+        let _ = shutdown.send(());
+        cleanup(&placeholder);
+    }
 }
 
 /// The envelope's `error_kind` has to reach the caller, or classifying failures

--- a/nyanpasu_ipc/tests/wire_golden.rs
+++ b/nyanpasu_ipc/tests/wire_golden.rs
@@ -719,11 +719,20 @@ fn the_error_kind_strings_are_pinned() {
             r#""apply_rollback_failed""#,
         ),
         (CoreErrorKind::StopUnconfirmed, r#""stop_unconfirmed""#),
+        // The control-plane admission and routing kinds (PR-A).
+        (CoreErrorKind::ShuttingDown, r#""shutting_down""#),
+        (CoreErrorKind::QueueFull, r#""queue_full""#),
+        (CoreErrorKind::OperationConflict, r#""operation_conflict""#),
+        (
+            CoreErrorKind::BackendUnavailable,
+            r#""backend_unavailable""#,
+        ),
+        (CoreErrorKind::Internal, r#""internal""#),
     ] {
         assert_eq!(serde_json::to_string(&kind).unwrap(), expected);
     }
     // Every kind is covered above; a new one must be added here too.
-    assert_eq!(CoreErrorKind::ALL.len(), 12);
+    assert_eq!(CoreErrorKind::ALL.len(), 17);
 }
 
 /// The new field is appended, so no existing key moves; the absent case is

--- a/nyanpasu_ipc/tests/wire_golden.rs
+++ b/nyanpasu_ipc/tests/wire_golden.rs
@@ -52,12 +52,16 @@ where
     envelope
 }
 
-fn error_envelope_with_kind<T>(msg: &'static str, kind: CoreErrorKind) -> R<'static, T>
+fn error_envelope_with_kind<T>(
+    msg: &'static str,
+    kind: CoreErrorKind,
+    retryable: Option<bool>,
+) -> R<'static, T>
 where
     T: serde::Serialize + serde::de::DeserializeOwned + std::fmt::Debug,
 {
     let mut envelope: R<'static, T> =
-        RBuilder::other_error_with_kind(Cow::Borrowed(msg), Some(kind));
+        RBuilder::other_error_with_kind(Cow::Borrowed(msg), Some(kind), retryable);
     envelope.ts = TS;
     envelope
 }
@@ -739,13 +743,34 @@ fn the_error_kind_strings_are_pinned() {
 /// pinned by every other envelope golden in this file staying unchanged.
 #[test]
 fn an_error_envelope_carries_its_kind() {
-    let envelope: R<'static, ()> =
-        error_envelope_with_kind("config revision conflict", CoreErrorKind::RevisionConflict);
+    let envelope: R<'static, ()> = error_envelope_with_kind(
+        "config revision conflict",
+        CoreErrorKind::RevisionConflict,
+        None,
+    );
     assert_eq!(
         serde_json::to_string(&envelope).unwrap(),
         concat!(
             r#"{"code":"OtherError","msg":"config revision conflict","data":null,"#,
             r#""ts":1700000000,"error_kind":"revision_conflict"}"#
+        )
+    );
+}
+
+/// `retryable` is appended after `error_kind`, and an unanswered one is still
+/// omitted — the literal above is the proof that adding it moved no key.
+#[test]
+fn an_error_envelope_carries_its_retryability() {
+    let envelope: R<'static, ()> = error_envelope_with_kind(
+        "the operation queue is full",
+        CoreErrorKind::QueueFull,
+        Some(true),
+    );
+    assert_eq!(
+        serde_json::to_string(&envelope).unwrap(),
+        concat!(
+            r#"{"code":"OtherError","msg":"the operation queue is full","data":null,"#,
+            r#""ts":1700000000,"error_kind":"queue_full","retryable":true}"#
         )
     );
 }
@@ -758,6 +783,7 @@ fn a_pre_s8_envelope_still_decodes() {
     let decoded: R<'static, ()> = serde_json::from_str(legacy).unwrap();
     assert_eq!(decoded.code, ResponseCode::OtherError);
     assert!(decoded.error_kind.is_none());
+    assert!(decoded.retryable.is_none());
 }
 
 #[test]


### PR DESCRIPTION
## 概要

控制面下沉的 runtime 仓部分（roadmap §6.5 的 **PR-A + PR-B**），基于 #390（typed `CoreErrorKind`）。Draft 状态供审计，**停止线 = legacy bridge 之前**：v1 wire 未删、行为并存加法。

## 提交 → 任务卡对照

| 提交 | 卡 | 内容 |
| --- | --- | --- |
| `1be4afd` | A1 | wire 表 12→17 kind（+`shutting_down`/`queue_full`/`operation_conflict`/`backend_unavailable`/`internal`） |
| `4156038` | A1 | `OperationId` / `CoreCommand`+envelope / `ConfigInput::Inline` / `CoreError`（kind 保持 `Option` 的 R0 诚实语义） |
| `2a30408` | A2 | `RuntimeBackend`/`RuntimeInstance` trait 边界，进程实现平移为 `ProcessRuntimeBackend` |
| `110bc21` | — | clippy: `as_chunks` hex parse |
| `9770f79` | A3 | 统一 `reconcile` 事务入口：CAS `expected_applied` → 内部 check 干净中止 → start/apply/switch 分派；`ApplyOutcome::Started` |
| `6cef53b` | A4+A5 | `CoreControl` handle + `ControlExecutor`：bounded 队列、幂等 registry（同 id+digest 附着 / 异 payload→`OperationConflict`）、closing latch、取消隔离 |
| `d453d76` | A6 | `DnsController` trait + `DnsOverrideRecord` 持久化 + 固定事务挂点（reconcile 尾 converge / stop·shutdown 头 restore / 建构期 orphan reconcile）+ `cfg(macos)` scutil 骨架 |
| `2092e4b` | A7 | in-memory fake backend 证明 trait 边界与 quarantine 契约 |
| `a3cf325` | B 前置 | 操作 long-poll（90s clamp），供 RPC host submit-query |
| `a02a092` | B1 | `/v2/core/{submit,operation,status}` 加法 wire + contract pin + client shortcuts |
| `faa76a0` | B2 | daemon 内嵌 `CoreControl`，v2 路由（submit-query；断线不取消）；ACL 沿用 |

## 审计要点

- 完整审计入口（代码位置 / 设计逐节对照 / 8 项记录在案偏离 / L1–L7 限制清单）在 app 仓配套 PR libnyanpasu/clash-nyanpasu#5116 的 `docs/audit/2026-08-13-v2-implementation-audit-guide.md`。
- 关键偏离摘要：`Check` 不是 `CoreCommand` 变体（独立方法+semaphore）；`CoreError.kind` 保持 `Option`（压过设计 §25 "kind 必在"）；retryable 由产生点决定；PR-B 不删 v1（bridge 阶段删除）。
- macOS DNS（scutil）在 Windows 上零编译零验证，仅结构+fake 测试可信（L1）。

## 验证

```
cargo test --workspace   # 461 通过
cargo clippy --workspace # 干净
```

重点套件：`control_plane` / `fake_backend` / `dns_override` / `reconcile`。

## 与 app 仓的关系

app 仓配套 draft PR libnyanpasu/clash-nyanpasu#5116（CoreActor v2 / ServiceActor / DNS 接线，并存不接线）以 path deps 依赖本分支工作树；submodule pin 移动待裁定后另行处理。
