### PR TITLE
refactor(core-manager): model each epoch as one plan

### DIFF
--- a/crates/nyanpasu-core-manager/src/config/mihomo.rs
+++ b/crates/nyanpasu-core-manager/src/config/mihomo.rs
@@ -577,6 +577,26 @@ mod tests {
     }
 
     #[test]
+    fn mihomo_effective_controller_rewrite_switches() {
+        // Same guarantee as above for the kind that *can* reconcile in place:
+        // a controller the orchestrator rewrote is never patched or reloaded,
+        // so an epoch's plan and its live instance cannot disagree on it.
+        let spec = spec(CoreKind::Mihomo, "mihomo");
+        assert!(matches!(
+            classify(
+                &mapping("mixed-port: 7890"),
+                &mapping("external-controller: 127.0.0.1:9090"),
+                &spec,
+                &mapping("mixed-port: 7890"),
+                &mapping("external-controller-pipe: /tmp/core-1.sock"),
+                &spec,
+            )
+            .unwrap(),
+            ConfigChange::Switch
+        ));
+    }
+
+    #[test]
     fn controller_process_and_unsupported_core_changes_switch() {
         let current = spec(CoreKind::Mihomo, "mihomo");
         let mut changed_binary = current.clone();

--- a/crates/nyanpasu-core-manager/src/manager/apply.rs
+++ b/crates/nyanpasu-core-manager/src/manager/apply.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::{
     Active, ApplyOutcome, CoreManager, Ctrl, EpochPlan, PreparedApply, abort_and_await,
-    quarantine::reject_quarantine, spawn_forwarder,
+    quarantine::reject_quarantine,
 };
 
 impl CoreManager {
@@ -306,14 +306,7 @@ impl CoreManager {
             Ok(instance) => {
                 let revision = desired.revision.clone();
                 let pid = instance.pid().unwrap_or_default();
-                let forwarder = spawn_forwarder(&self.inner, instance.state(), revision.epoch);
-                ctrl.last_spec = Some(desired.source_spec.clone());
-                ctrl.current = Some(Active {
-                    instance,
-                    forwarder,
-                    plan: desired,
-                });
-                let active = ctrl.current.as_ref().expect("just installed");
+                let active = self.install(ctrl, instance, desired);
                 self.inner.publish_active(
                     active,
                     CoreState::Running {
@@ -354,15 +347,7 @@ impl CoreManager {
                     Ok(instance) => {
                         let revision = old_plan.revision.clone();
                         let pid = instance.pid().unwrap_or_default();
-                        let forwarder =
-                            spawn_forwarder(&self.inner, instance.state(), revision.epoch);
-                        ctrl.last_spec = Some(old_plan.source_spec.clone());
-                        ctrl.current = Some(Active {
-                            instance,
-                            forwarder,
-                            plan: old_plan,
-                        });
-                        let active = ctrl.current.as_ref().expect("rollback installed");
+                        let active = self.install(ctrl, instance, old_plan);
                         self.inner.publish_active(
                             active,
                             CoreState::Running {
@@ -437,14 +422,7 @@ impl CoreManager {
             Ok(instance) => {
                 let revision = desired.revision.clone();
                 let pid = instance.pid().unwrap_or_default();
-                let forwarder = spawn_forwarder(&self.inner, instance.state(), revision.epoch);
-                ctrl.last_spec = Some(desired.source_spec.clone());
-                ctrl.current = Some(Active {
-                    instance,
-                    forwarder,
-                    plan: desired,
-                });
-                let active = ctrl.current.as_ref().expect("switch installed");
+                let active = self.install(ctrl, instance, desired);
                 self.inner.publish_active(
                     active,
                     CoreState::Running {
@@ -481,15 +459,7 @@ impl CoreManager {
                     Ok(instance) => {
                         let revision = old_plan.revision.clone();
                         let pid = instance.pid().unwrap_or_default();
-                        let forwarder =
-                            spawn_forwarder(&self.inner, instance.state(), revision.epoch);
-                        ctrl.last_spec = Some(old_plan.source_spec.clone());
-                        ctrl.current = Some(Active {
-                            instance,
-                            forwarder,
-                            plan: old_plan,
-                        });
-                        let active = ctrl.current.as_ref().expect("switch rollback installed");
+                        let active = self.install(ctrl, instance, old_plan);
                         self.inner.publish_active(
                             active,
                             CoreState::Running {

--- a/crates/nyanpasu-core-manager/src/manager/apply.rs
+++ b/crates/nyanpasu-core-manager/src/manager/apply.rs
@@ -386,7 +386,7 @@ impl CoreManager {
         input: InstanceSpec,
         snapshot: ConfigSnapshot,
     ) -> Result<ApplyOutcome, Error> {
-        let epoch = self.next_epoch();
+        let epoch = ctrl.epochs.next();
         let desired = self.prepare_launch(&input, epoch, &snapshot).await?;
         let old_plan = match self.retire_current(ctrl).await {
             Ok(retired) => retired.expect("current held by control lock"),

--- a/crates/nyanpasu-core-manager/src/manager/apply.rs
+++ b/crates/nyanpasu-core-manager/src/manager/apply.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 use super::{
-    Active, ApplyOutcome, CoreManager, Ctrl, EpochPlan, PreparedApply, abort_and_await,
+    Active, ApplyOutcome, CoreManager, Ctrl, EpochPlan, PreparedApply, RetireFailure,
     quarantine::reject_quarantine,
 };
 
@@ -276,23 +276,20 @@ impl CoreManager {
         desired: EpochPlan,
         backup: crate::RuntimeConfigBackup,
     ) -> Result<ApplyOutcome, Error> {
-        let Active {
-            instance: old_instance,
-            forwarder: old_forwarder,
-            plan: old_plan,
-        } = ctrl.current.take().expect("current held by control lock");
-        abort_and_await(old_forwarder).await;
-        if let Err(error) = old_instance
-            .stop_and_confirm_dead(self.inner.options.stop_timeout)
-            .await
-        {
-            if matches!(error, Error::StopUnconfirmed(_)) {
-                return Err(self.latch_quarantine(ctrl, old_plan.revision.epoch, error));
+        let old_plan = match self.retire_current(ctrl).await {
+            Ok(retired) => retired.expect("current held by control lock"),
+            Err(RetireFailure {
+                epoch: retired_epoch,
+                error,
+            }) => {
+                if matches!(error, Error::StopUnconfirmed(_)) {
+                    return Err(self.latch_quarantine(ctrl, retired_epoch, error));
+                }
+                let message = format!("failed to stop current epoch for reconcile: {error}");
+                self.publish_terminal_error(&Error::ApplyFailed(message.clone()));
+                return Err(Error::ApplyFailed(message));
             }
-            let message = format!("failed to stop current epoch for reconcile: {error}");
-            self.publish_terminal_error(&Error::ApplyFailed(message.clone()));
-            return Err(Error::ApplyFailed(message));
-        }
+        };
 
         self.inner.publish(
             CoreState::Restarting {
@@ -391,24 +388,21 @@ impl CoreManager {
     ) -> Result<ApplyOutcome, Error> {
         let epoch = self.next_epoch();
         let desired = self.prepare_launch(&input, epoch, &snapshot).await?;
-        let Active {
-            instance: old_instance,
-            forwarder: old_forwarder,
-            plan: old_plan,
-        } = ctrl.current.take().expect("current held by control lock");
-        abort_and_await(old_forwarder).await;
-        if let Err(error) = old_instance
-            .stop_and_confirm_dead(self.inner.options.stop_timeout)
-            .await
-        {
-            let _ = self.inner.store.cleanup_epoch(epoch).await;
-            if matches!(error, Error::StopUnconfirmed(_)) {
-                return Err(self.latch_quarantine(ctrl, old_plan.revision.epoch, error));
+        let old_plan = match self.retire_current(ctrl).await {
+            Ok(retired) => retired.expect("current held by control lock"),
+            Err(RetireFailure {
+                epoch: retired_epoch,
+                error,
+            }) => {
+                let _ = self.inner.store.cleanup_epoch(epoch).await;
+                if matches!(error, Error::StopUnconfirmed(_)) {
+                    return Err(self.latch_quarantine(ctrl, retired_epoch, error));
+                }
+                let message = format!("failed to stop current epoch for switch: {error}");
+                self.publish_terminal_error(&Error::ApplyFailed(message.clone()));
+                return Err(Error::ApplyFailed(message));
             }
-            let message = format!("failed to stop current epoch for switch: {error}");
-            self.publish_terminal_error(&Error::ApplyFailed(message.clone()));
-            return Err(Error::ApplyFailed(message));
-        }
+        };
 
         self.inner.publish(
             CoreState::Switching {

--- a/crates/nyanpasu-core-manager/src/manager/apply.rs
+++ b/crates/nyanpasu-core-manager/src/manager/apply.rs
@@ -11,8 +11,8 @@ use crate::{
 };
 
 use super::{
-    Active, ApplyOutcome, CoreManager, Ctrl, PreparedApply, PreparedLaunch, abort_and_await,
-    publish::spec_summary, quarantine::reject_quarantine, spawn_forwarder,
+    Active, ApplyOutcome, CoreManager, Ctrl, EpochPlan, PreparedApply, abort_and_await,
+    quarantine::reject_quarantine, spawn_forwarder,
 };
 
 impl CoreManager {
@@ -38,7 +38,7 @@ impl CoreManager {
         if current.instance.state().borrow().state.is_terminal() {
             return Err(Error::NotStarted);
         }
-        let actual_revision = current.revision.id();
+        let actual_revision = current.plan.revision.id();
         if let Some(expected) = expected_revision
             && expected != actual_revision
         {
@@ -53,16 +53,16 @@ impl CoreManager {
             .prepare_apply(current, input.clone(), &snapshot)
             .await?;
         let change = mihomo::classify(
-            &current.source_document,
-            &current.effective_document,
-            &current.source_spec,
-            &prepared.source_document,
-            &prepared.effective_document,
-            &prepared.source_spec,
+            &current.plan.source_document,
+            &current.plan.effective_document,
+            &current.plan.source_spec,
+            &prepared.plan.source_document,
+            &prepared.plan.effective_document,
+            &prepared.plan.source_spec,
         )?;
         if matches!(change, ConfigChange::Noop) {
             return Ok(ApplyOutcome::Noop {
-                revision: current.revision.clone(),
+                revision: current.plan.revision.clone(),
             });
         }
         if matches!(change, ConfigChange::Switch) {
@@ -73,23 +73,19 @@ impl CoreManager {
         let backup = self
             .inner
             .store
-            .backup(current.revision.epoch, prepared.revision.generation)
+            .backup(
+                current.plan.revision.epoch,
+                prepared.plan.revision.generation,
+            )
             .await?;
         let PreparedApply {
-            source_spec,
-            effective_spec,
-            controller,
-            revision,
-            capabilities,
-            runtime_features,
-            source_document,
-            effective_document,
+            plan: desired,
             staged,
         } = prepared;
         let commit = match self
             .inner
             .store
-            .commit_replace(staged, revision.epoch)
+            .commit_replace(staged, desired.revision.epoch)
             .await
         {
             Ok(commit) => commit,
@@ -99,16 +95,6 @@ impl CoreManager {
             }
         };
         let durability_warning = commit.durability_warning().map(str::to_owned);
-        let desired = PreparedLaunch {
-            source_spec,
-            effective_spec,
-            controller,
-            revision,
-            capabilities,
-            runtime_features,
-            source_document,
-            effective_document,
-        };
 
         let reconciled = tokio::time::timeout(
             self.inner.options.reconcile_timeout,
@@ -127,24 +113,16 @@ impl CoreManager {
                 },
                 ConfigChange::Noop | ConfigChange::Switch => unreachable!(),
             };
-            let source_spec = {
-                let active = ctrl.current.as_mut().expect("current held by control lock");
-                active.source_spec = desired.source_spec;
-                active.revision = desired.revision;
-                active.capabilities = desired.capabilities;
-                active.runtime_features = desired.runtime_features;
-                active.source_document = desired.source_document;
-                active.effective_document = desired.effective_document;
-                self.inner.publish_active(
-                    active,
-                    CoreState::Running {
-                        epoch: revision.epoch,
-                        pid: active.instance.pid().unwrap_or_default(),
-                    },
-                );
-                active.source_spec.clone()
-            };
-            ctrl.last_spec = Some(source_spec);
+            let active = ctrl.current.as_mut().expect("current held by control lock");
+            active.plan = desired;
+            self.inner.publish_active(
+                active,
+                CoreState::Running {
+                    epoch: revision.epoch,
+                    pid: active.instance.pid().unwrap_or_default(),
+                },
+            );
+            ctrl.last_spec = Some(active.plan.source_spec.clone());
             if let Err(error) = self.inner.store.remove_backup(backup).await {
                 tracing::warn!("failed to remove successful apply backup: {error}");
             }
@@ -163,7 +141,7 @@ impl CoreManager {
     ) -> Result<PreparedApply, Error> {
         self.validate_launchable(&input).await?;
         let resolved = self.resolve_features(&input.core).await?;
-        let epoch = current.revision.epoch;
+        let epoch = current.plan.revision.epoch;
         let prepared = snapshot.prepare_full(
             self.inner.options.controller_template.as_deref(),
             self.inner.store.dir(),
@@ -180,25 +158,27 @@ impl CoreManager {
         check_spec.config_path = staged.path().to_owned();
         self.inner.backend.check_config(&check_spec).await?;
 
-        let runtime_path = current.revision.runtime_path.clone();
+        let runtime_path = current.plan.revision.runtime_path.clone();
         let mut effective_spec = input.clone();
         effective_spec.config_path = runtime_path.clone();
         effective_spec.pid_file = Some(self.inner.store.pid_path(epoch));
         Ok(PreparedApply {
-            source_spec: input,
-            effective_spec,
-            controller: prepared.controller,
-            revision: ConfigRevision {
-                epoch,
-                generation: current.revision.generation + 1,
-                source_hash: prepared.source_hash,
-                effective_hash: prepared.effective_hash,
-                runtime_path,
+            plan: EpochPlan {
+                source_spec: input,
+                effective_spec,
+                controller: prepared.controller,
+                revision: ConfigRevision {
+                    epoch,
+                    generation: current.plan.revision.generation + 1,
+                    source_hash: prepared.source_hash,
+                    effective_hash: prepared.effective_hash,
+                    runtime_path,
+                },
+                capabilities: resolved.capabilities,
+                runtime_features: resolved.runtime,
+                source_document: snapshot.document().clone(),
+                effective_document: prepared.document,
             },
-            capabilities: resolved.capabilities,
-            runtime_features: resolved.runtime,
-            source_document: snapshot.document().clone(),
-            effective_document: prepared.document,
             staged,
         })
     }
@@ -207,7 +187,7 @@ impl CoreManager {
         &self,
         current: &Active,
         change: &ConfigChange,
-        desired: &PreparedLaunch,
+        desired: &EpochPlan,
     ) -> bool {
         if let ConfigChange::Patch { patch, projection } = change {
             return self
@@ -293,26 +273,21 @@ impl CoreManager {
     async fn restart_with_compensation(
         &self,
         ctrl: &mut Ctrl,
-        desired: PreparedLaunch,
+        desired: EpochPlan,
         backup: crate::RuntimeConfigBackup,
     ) -> Result<ApplyOutcome, Error> {
-        let old = ctrl.current.take().expect("current held by control lock");
-        let old_effective_spec = old.instance.spec().clone();
-        let old_controller = old.instance.controller().clone();
-        let old_source_spec = old.source_spec.clone();
-        let old_revision = old.revision.clone();
-        let old_capabilities = old.capabilities;
-        let old_runtime_features = old.runtime_features;
-        let old_source_document = old.source_document.clone();
-        let old_effective_document = old.effective_document.clone();
-        abort_and_await(old.forwarder).await;
-        if let Err(error) = old
-            .instance
+        let Active {
+            instance: old_instance,
+            forwarder: old_forwarder,
+            plan: old_plan,
+        } = ctrl.current.take().expect("current held by control lock");
+        abort_and_await(old_forwarder).await;
+        if let Err(error) = old_instance
             .stop_and_confirm_dead(self.inner.options.stop_timeout)
             .await
         {
             if matches!(error, Error::StopUnconfirmed(_)) {
-                return Err(self.latch_quarantine(ctrl, old_revision.epoch, error));
+                return Err(self.latch_quarantine(ctrl, old_plan.revision.epoch, error));
             }
             let message = format!("failed to stop current epoch for reconcile: {error}");
             self.publish_terminal_error(&Error::ApplyFailed(message.clone()));
@@ -324,23 +299,10 @@ impl CoreManager {
                 epoch: desired.revision.epoch,
                 attempt: 0,
             },
-            Some(spec_summary(
-                &desired.source_spec,
-                desired.capabilities,
-                desired.runtime_features,
-            )),
-            Some(desired.controller.host.clone()),
-            Some(desired.revision.clone()),
+            Some(&desired),
         );
 
-        match self
-            .spawn_replacement(
-                desired.effective_spec.clone(),
-                desired.revision.epoch,
-                desired.controller.clone(),
-            )
-            .await
-        {
+        match self.spawn_replacement(&desired).await {
             Ok(instance) => {
                 let revision = desired.revision.clone();
                 let pid = instance.pid().unwrap_or_default();
@@ -349,12 +311,7 @@ impl CoreManager {
                 ctrl.current = Some(Active {
                     instance,
                     forwarder,
-                    source_spec: desired.source_spec,
-                    revision: desired.revision,
-                    capabilities: desired.capabilities,
-                    runtime_features: desired.runtime_features,
-                    source_document: desired.source_document,
-                    effective_document: desired.effective_document,
+                    plan: desired,
                 });
                 let active = ctrl.current.as_ref().expect("just installed");
                 self.inner.publish_active(
@@ -388,41 +345,28 @@ impl CoreManager {
                 let restore_warning = restore.durability_warning().map(str::to_owned);
                 self.inner.publish(
                     CoreState::Restarting {
-                        epoch: old_revision.epoch,
+                        epoch: old_plan.revision.epoch,
                         attempt: 0,
                     },
-                    Some(spec_summary(
-                        &old_source_spec,
-                        old_capabilities,
-                        old_runtime_features,
-                    )),
-                    Some(old_controller.host.clone()),
-                    Some(old_revision.clone()),
+                    Some(&old_plan),
                 );
-                let rollback = match self
-                    .spawn_replacement(old_effective_spec, old_revision.epoch, old_controller)
-                    .await
-                {
+                let rollback = match self.spawn_replacement(&old_plan).await {
                     Ok(instance) => {
+                        let revision = old_plan.revision.clone();
                         let pid = instance.pid().unwrap_or_default();
                         let forwarder =
-                            spawn_forwarder(&self.inner, instance.state(), old_revision.epoch);
-                        ctrl.last_spec = Some(old_source_spec.clone());
+                            spawn_forwarder(&self.inner, instance.state(), revision.epoch);
+                        ctrl.last_spec = Some(old_plan.source_spec.clone());
                         ctrl.current = Some(Active {
                             instance,
                             forwarder,
-                            source_spec: old_source_spec,
-                            revision: old_revision.clone(),
-                            capabilities: old_capabilities,
-                            runtime_features: old_runtime_features,
-                            source_document: old_source_document,
-                            effective_document: old_effective_document,
+                            plan: old_plan,
                         });
                         let active = ctrl.current.as_ref().expect("rollback installed");
                         self.inner.publish_active(
                             active,
                             CoreState::Running {
-                                epoch: old_revision.epoch,
+                                epoch: revision.epoch,
                                 pid,
                             },
                         );
@@ -430,7 +374,7 @@ impl CoreManager {
                             tracing::warn!("failed to remove rollback backup: {error}");
                         }
                         Ok(ApplyOutcome::RolledBack {
-                            revision: old_revision,
+                            revision,
                             failed_apply: apply_text,
                         })
                     }
@@ -438,7 +382,7 @@ impl CoreManager {
                         let error = Error::StopUnconfirmed(format!(
                             "desired apply failed ({apply_text}); rollback replacement {rollback_error}"
                         ));
-                        Err(self.latch_quarantine(ctrl, old_revision.epoch, error))
+                        Err(self.latch_quarantine(ctrl, old_plan.revision.epoch, error))
                     }
                     Err(rollback_error) => {
                         let error = Error::ApplyRollbackFailed {
@@ -462,25 +406,19 @@ impl CoreManager {
     ) -> Result<ApplyOutcome, Error> {
         let epoch = self.next_epoch();
         let desired = self.prepare_launch(&input, epoch, &snapshot).await?;
-        let old = ctrl.current.take().expect("current held by control lock");
-        let old_epoch = old.revision.epoch;
-        let old_effective_spec = old.instance.spec().clone();
-        let old_controller = old.instance.controller().clone();
-        let old_source_spec = old.source_spec.clone();
-        let old_revision = old.revision.clone();
-        let old_capabilities = old.capabilities;
-        let old_runtime_features = old.runtime_features;
-        let old_source_document = old.source_document.clone();
-        let old_effective_document = old.effective_document.clone();
-        abort_and_await(old.forwarder).await;
-        if let Err(error) = old
-            .instance
+        let Active {
+            instance: old_instance,
+            forwarder: old_forwarder,
+            plan: old_plan,
+        } = ctrl.current.take().expect("current held by control lock");
+        abort_and_await(old_forwarder).await;
+        if let Err(error) = old_instance
             .stop_and_confirm_dead(self.inner.options.stop_timeout)
             .await
         {
             let _ = self.inner.store.cleanup_epoch(epoch).await;
             if matches!(error, Error::StopUnconfirmed(_)) {
-                return Err(self.latch_quarantine(ctrl, old_epoch, error));
+                return Err(self.latch_quarantine(ctrl, old_plan.revision.epoch, error));
             }
             let message = format!("failed to stop current epoch for switch: {error}");
             self.publish_terminal_error(&Error::ApplyFailed(message.clone()));
@@ -489,26 +427,13 @@ impl CoreManager {
 
         self.inner.publish(
             CoreState::Switching {
-                from: Some(old_epoch),
+                from: Some(old_plan.revision.epoch),
                 to: desired.revision.epoch,
             },
-            Some(spec_summary(
-                &desired.source_spec,
-                desired.capabilities,
-                desired.runtime_features,
-            )),
-            Some(desired.controller.host.clone()),
-            Some(desired.revision.clone()),
+            Some(&desired),
         );
 
-        match self
-            .spawn_replacement(
-                desired.effective_spec.clone(),
-                desired.revision.epoch,
-                desired.controller.clone(),
-            )
-            .await
-        {
+        match self.spawn_replacement(&desired).await {
             Ok(instance) => {
                 let revision = desired.revision.clone();
                 let pid = instance.pid().unwrap_or_default();
@@ -517,12 +442,7 @@ impl CoreManager {
                 ctrl.current = Some(Active {
                     instance,
                     forwarder,
-                    source_spec: desired.source_spec,
-                    revision: desired.revision,
-                    capabilities: desired.capabilities,
-                    runtime_features: desired.runtime_features,
-                    source_document: desired.source_document,
-                    effective_document: desired.effective_document,
+                    plan: desired,
                 });
                 let active = ctrl.current.as_ref().expect("switch installed");
                 self.inner.publish_active(
@@ -532,7 +452,12 @@ impl CoreManager {
                         pid,
                     },
                 );
-                if let Err(error) = self.inner.store.cleanup_epoch(old_epoch).await {
+                if let Err(error) = self
+                    .inner
+                    .store
+                    .cleanup_epoch(old_plan.revision.epoch)
+                    .await
+                {
                     tracing::warn!("failed to clean switched-out epoch: {error}");
                 }
                 Ok(ApplyOutcome::Switched { revision })
@@ -547,46 +472,33 @@ impl CoreManager {
                 }
                 self.inner.publish(
                     CoreState::Restarting {
-                        epoch: old_revision.epoch,
+                        epoch: old_plan.revision.epoch,
                         attempt: 0,
                     },
-                    Some(spec_summary(
-                        &old_source_spec,
-                        old_capabilities,
-                        old_runtime_features,
-                    )),
-                    Some(old_controller.host.clone()),
-                    Some(old_revision.clone()),
+                    Some(&old_plan),
                 );
-                match self
-                    .spawn_replacement(old_effective_spec, old_revision.epoch, old_controller)
-                    .await
-                {
+                match self.spawn_replacement(&old_plan).await {
                     Ok(instance) => {
+                        let revision = old_plan.revision.clone();
                         let pid = instance.pid().unwrap_or_default();
                         let forwarder =
-                            spawn_forwarder(&self.inner, instance.state(), old_revision.epoch);
-                        ctrl.last_spec = Some(old_source_spec.clone());
+                            spawn_forwarder(&self.inner, instance.state(), revision.epoch);
+                        ctrl.last_spec = Some(old_plan.source_spec.clone());
                         ctrl.current = Some(Active {
                             instance,
                             forwarder,
-                            source_spec: old_source_spec,
-                            revision: old_revision.clone(),
-                            capabilities: old_capabilities,
-                            runtime_features: old_runtime_features,
-                            source_document: old_source_document,
-                            effective_document: old_effective_document,
+                            plan: old_plan,
                         });
                         let active = ctrl.current.as_ref().expect("switch rollback installed");
                         self.inner.publish_active(
                             active,
                             CoreState::Running {
-                                epoch: old_revision.epoch,
+                                epoch: revision.epoch,
                                 pid,
                             },
                         );
                         Ok(ApplyOutcome::RolledBack {
-                            revision: old_revision,
+                            revision,
                             failed_apply: apply_text,
                         })
                     }
@@ -594,7 +506,7 @@ impl CoreManager {
                         let error = Error::StopUnconfirmed(format!(
                             "desired switch failed ({apply_text}); rollback replacement {rollback_error}"
                         ));
-                        Err(self.latch_quarantine(ctrl, old_revision.epoch, error))
+                        Err(self.latch_quarantine(ctrl, old_plan.revision.epoch, error))
                     }
                     Err(rollback_error) => {
                         let error = Error::ApplyRollbackFailed {

--- a/crates/nyanpasu-core-manager/src/manager/dns_sync.rs
+++ b/crates/nyanpasu-core-manager/src/manager/dns_sync.rs
@@ -84,7 +84,7 @@ impl CoreManager {
             let running = !active.instance.state().borrow().state.is_terminal();
             running
                 .then(|| {
-                    dns.desired(&active.effective_document)
+                    dns.desired(&active.plan.effective_document)
                         .map(|intent| (intent, active.instance.epoch()))
                 })
                 .flatten()

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -8,10 +8,7 @@ mod quarantine;
 mod reconcile;
 mod switching;
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicU64, Ordering},
-};
+use std::sync::Arc;
 
 use enumset::EnumSet;
 use serde_yaml_ng::Mapping;
@@ -119,7 +116,6 @@ struct Inner {
     /// Outlives every epoch, so callers can subscribe before the first start and
     /// keep receiving across restarts and core switches.
     log_tx: broadcast::Sender<Arc<LogFrame>>,
-    epoch: AtomicU64,
     version_cache: VersionCache,
     /// `Some` while the JSONL sink is running. `None` means the caller turned it
     /// off, and there is deliberately no path to report — nothing will ever
@@ -134,14 +130,47 @@ struct Inner {
     _runtime_lock: RuntimeDirectoryLock,
 }
 
-#[derive(Default)]
 struct Ctrl {
+    epochs: EpochAllocator,
     current: Option<Active>,
     last_spec: Option<InstanceSpec>,
     quarantine: Vec<QuarantinedEpoch>,
     /// The persisted-and-live DNS override, when a controller is injected and
     /// an override is in place. Serialized by the control lock like the rest.
     dns_record: Option<DnsOverrideRecord>,
+}
+
+impl Ctrl {
+    fn new(max_epoch: u64) -> Self {
+        Self {
+            epochs: EpochAllocator::seeded(max_epoch),
+            current: None,
+            last_spec: None,
+            quarantine: Vec::new(),
+            dns_record: None,
+        }
+    }
+}
+
+/// Hands out epoch numbers: monotone for the manager's lifetime and seeded
+/// past every artifact found on disk, so a number is never reused within one
+/// runtime directory. It lives under the control lock because every allocation
+/// happens inside a control transaction, which is also why it is not atomic.
+/// Never returns 0, which is reserved for "no epoch"; exhausting 2^64 epochs in
+/// one directory is an invariant violation, not a wrap.
+struct EpochAllocator {
+    last: u64,
+}
+
+impl EpochAllocator {
+    fn seeded(max_seen: u64) -> Self {
+        Self { last: max_seen }
+    }
+
+    fn next(&mut self) -> u64 {
+        self.last = self.last.checked_add(1).expect("epoch space exhausted");
+        self.last
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -323,10 +352,9 @@ impl CoreManager {
                 backend,
                 dns,
                 store,
-                ctrl: tokio::sync::Mutex::default(),
+                ctrl: tokio::sync::Mutex::new(Ctrl::new(max_epoch)),
                 status_tx,
                 log_tx,
-                epoch: AtomicU64::new(max_epoch),
                 version_cache: VersionCache::default(),
                 log_dir,
                 log_sink: tokio::sync::Mutex::new(log_sink),
@@ -377,7 +405,7 @@ impl CoreManager {
     }
 
     async fn start_locked(&self, ctrl: &mut Ctrl, spec: InstanceSpec) -> Result<(), Error> {
-        let epoch = self.next_epoch();
+        let epoch = ctrl.epochs.next();
         let snapshot = match ConfigSnapshot::load(&spec.config_path).await {
             Ok(snapshot) => snapshot,
             Err(error) => {
@@ -581,10 +609,6 @@ impl CoreManager {
         result
     }
 
-    fn next_epoch(&self) -> u64 {
-        self.inner.epoch.fetch_add(1, Ordering::Relaxed) + 1
-    }
-
     async fn spawn_instance(&self, plan: &EpochPlan) -> Result<Box<dyn RuntimeInstance>, Error> {
         self.inner
             .backend
@@ -682,4 +706,23 @@ fn spawn_forwarder(
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EpochAllocator;
+
+    #[test]
+    fn epochs_are_monotone_past_the_seed_and_never_zero() {
+        let mut fresh = EpochAllocator::seeded(0);
+        assert_eq!(fresh.next(), 1);
+        let mut seeded = EpochAllocator::seeded(7);
+        assert_eq!((seeded.next(), seeded.next()), (8, 9));
+    }
+
+    #[test]
+    #[should_panic(expected = "epoch space exhausted")]
+    fn epoch_exhaustion_is_an_invariant_violation_not_a_wrap() {
+        EpochAllocator::seeded(u64::MAX).next();
+    }
 }

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -173,6 +173,15 @@ struct Active {
     plan: EpochPlan,
 }
 
+/// A stop that could not be proven, carrying the epoch it belongs to. What to
+/// do about it — discard a half-built candidate first, wrap the error, publish,
+/// latch quarantine — differs per transaction and stays with the caller, in the
+/// order that caller already has.
+struct RetireFailure {
+    epoch: u64,
+    error: Error,
+}
+
 struct PreparedGraceful {
     plan: EpochPlan,
     full_staged: StagedRuntimeConfig,
@@ -363,21 +372,7 @@ impl CoreManager {
         if running {
             return Err(Error::AlreadyRunning);
         }
-        if let Some(stale) = ctrl.current.take() {
-            abort_and_await(stale.forwarder).await;
-            let epoch = stale.instance.epoch();
-            if let Err(error) = stale
-                .instance
-                .stop_and_confirm_dead(self.inner.options.stop_timeout)
-                .await
-            {
-                if matches!(error, Error::StopUnconfirmed(_)) {
-                    return Err(self.latch_quarantine(&mut ctrl, epoch, error));
-                }
-                return Err(error);
-            }
-            self.inner.store.cleanup_epoch(epoch).await?;
-        }
+        self.discard_stale(&mut ctrl).await?;
         self.start_locked(&mut ctrl, spec).await
     }
 
@@ -621,6 +616,45 @@ impl CoreManager {
             forwarder,
             plan,
         })
+    }
+
+    /// The mechanics every stop shares: take the epoch out of the slot, silence
+    /// its forwarder, prove the process dead. Publishes nothing and latches no
+    /// quarantine — an unproven stop comes back as [`RetireFailure`] for the
+    /// caller to place in its own sequence.
+    async fn retire_current(&self, ctrl: &mut Ctrl) -> Result<Option<EpochPlan>, RetireFailure> {
+        let Some(Active {
+            instance,
+            forwarder,
+            plan,
+        }) = ctrl.current.take()
+        else {
+            return Ok(None);
+        };
+        abort_and_await(forwarder).await;
+        let epoch = plan.revision.epoch;
+        instance
+            .stop_and_confirm_dead(self.inner.options.stop_timeout)
+            .await
+            .map_err(|error| RetireFailure { epoch, error })?;
+        Ok(Some(plan))
+    }
+
+    /// Stale-epoch hygiene shared by start, switch and reconcile: a terminal
+    /// epoch still sitting in the slot is retired and its artifacts removed
+    /// before the slot is reused.
+    async fn discard_stale(&self, ctrl: &mut Ctrl) -> Result<(), Error> {
+        match self.retire_current(ctrl).await {
+            Ok(None) => Ok(()),
+            Ok(Some(plan)) => self.inner.store.cleanup_epoch(plan.revision.epoch).await,
+            Err(RetireFailure { epoch, error }) => {
+                Err(if matches!(error, Error::StopUnconfirmed(_)) {
+                    self.latch_quarantine(ctrl, epoch, error)
+                } else {
+                    error
+                })
+            }
+        }
     }
 }
 

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -436,13 +436,7 @@ impl CoreManager {
         let pid = instance.pid().unwrap_or_default();
         self.inner
             .publish_instance(instance.as_ref(), CoreState::Running { epoch, pid }, &plan);
-        let forwarder = spawn_forwarder(&self.inner, instance.state(), epoch);
-        ctrl.last_spec = Some(plan.source_spec.clone());
-        ctrl.current = Some(Active {
-            instance,
-            forwarder,
-            plan,
-        });
+        self.install(ctrl, instance, plan);
         Ok(())
     }
 
@@ -606,6 +600,27 @@ impl CoreManager {
                 log_tx: self.inner.log_tx.clone(),
             })
             .await
+    }
+
+    /// The one place an epoch enters the slot: forwarder, retained spec,
+    /// current. Publishes nothing. Every caller keeps its own `Running`
+    /// publication where it is today — before this call in `start` and the
+    /// graceful switch, after it in the apply compensations. The forwarder
+    /// publishes without the control lock, so which frame reaches the watch
+    /// first is observable downstream and is not this function's to decide.
+    fn install<'c>(
+        &self,
+        ctrl: &'c mut Ctrl,
+        instance: Box<dyn RuntimeInstance>,
+        plan: EpochPlan,
+    ) -> &'c mut Active {
+        let forwarder = spawn_forwarder(&self.inner, instance.state(), plan.revision.epoch);
+        ctrl.last_spec = Some(plan.source_spec.clone());
+        ctrl.current.insert(Active {
+            instance,
+            forwarder,
+            plan,
+        })
     }
 }
 

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -35,7 +35,7 @@ use crate::{
     state::{ConfigRevision, CoreState, CoreStatus, InstanceStatus, StopReason},
 };
 
-use publish::{instance_core_state, spec_summary};
+use publish::instance_core_state;
 use quarantine::{reject_quarantine, sweep_orphans};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -151,18 +151,12 @@ struct QuarantinedEpoch {
     death_proven: bool,
 }
 
-struct Active {
-    instance: Box<dyn RuntimeInstance>,
-    forwarder: tokio::task::JoinHandle<()>,
-    source_spec: InstanceSpec,
-    revision: ConfigRevision,
-    capabilities: EnumSet<Feature>,
-    runtime_features: EnumSet<RuntimeFeature>,
-    source_document: Mapping,
-    effective_document: Mapping,
-}
-
-struct PreparedLaunch {
+/// Everything the manager knows about one epoch besides the live process.
+/// Built once by a prepare step, carried whole into [`Active`], and reused
+/// verbatim to relaunch the same epoch on rollback. Deliberately not `Clone`:
+/// every consumer moves or borrows it; a clone would be two sources of truth
+/// for one epoch.
+struct EpochPlan {
     source_spec: InstanceSpec,
     effective_spec: InstanceSpec,
     controller: ResolvedController,
@@ -173,21 +167,20 @@ struct PreparedLaunch {
     effective_document: Mapping,
 }
 
+struct Active {
+    instance: Box<dyn RuntimeInstance>,
+    forwarder: tokio::task::JoinHandle<()>,
+    plan: EpochPlan,
+}
+
 struct PreparedGraceful {
-    launch: PreparedLaunch,
+    plan: EpochPlan,
     full_staged: StagedRuntimeConfig,
     restoration: Option<(Box<clash_api::ConfigPatch>, mihomo::RuntimeProjection)>,
 }
 
 struct PreparedApply {
-    source_spec: InstanceSpec,
-    effective_spec: InstanceSpec,
-    controller: ResolvedController,
-    revision: ConfigRevision,
-    capabilities: EnumSet<Feature>,
-    runtime_features: EnumSet<RuntimeFeature>,
-    source_document: Mapping,
-    effective_document: Mapping,
+    plan: EpochPlan,
     staged: StagedRuntimeConfig,
 }
 
@@ -408,22 +401,11 @@ impl CoreManager {
         self.start_prepared(ctrl, prepared).await
     }
 
-    async fn start_prepared(&self, ctrl: &mut Ctrl, prepared: PreparedLaunch) -> Result<(), Error> {
-        let epoch = prepared.revision.epoch;
-        self.inner.publish(
-            CoreState::Starting { epoch },
-            Some(spec_summary(
-                &prepared.source_spec,
-                prepared.capabilities,
-                prepared.runtime_features,
-            )),
-            Some(prepared.controller.host.clone()),
-            Some(prepared.revision.clone()),
-        );
-        let instance = match self
-            .spawn_instance(prepared.effective_spec, epoch, prepared.controller)
-            .await
-        {
+    async fn start_prepared(&self, ctrl: &mut Ctrl, plan: EpochPlan) -> Result<(), Error> {
+        let epoch = plan.revision.epoch;
+        self.inner
+            .publish(CoreState::Starting { epoch }, Some(&plan));
+        let instance = match self.spawn_instance(&plan).await {
             Ok(instance) => instance,
             Err(error) => {
                 let _ = self.inner.store.cleanup_epoch(epoch).await;
@@ -452,25 +434,14 @@ impl CoreManager {
         }
 
         let pid = instance.pid().unwrap_or_default();
-        self.inner.publish_instance(
-            instance.as_ref(),
-            CoreState::Running { epoch, pid },
-            &prepared.source_spec,
-            &prepared.revision,
-            prepared.capabilities,
-            prepared.runtime_features,
-        );
+        self.inner
+            .publish_instance(instance.as_ref(), CoreState::Running { epoch, pid }, &plan);
         let forwarder = spawn_forwarder(&self.inner, instance.state(), epoch);
-        ctrl.last_spec = Some(prepared.source_spec.clone());
+        ctrl.last_spec = Some(plan.source_spec.clone());
         ctrl.current = Some(Active {
             instance,
             forwarder,
-            source_spec: prepared.source_spec,
-            revision: prepared.revision,
-            capabilities: prepared.capabilities,
-            runtime_features: prepared.runtime_features,
-            source_document: prepared.source_document,
-            effective_document: prepared.effective_document,
+            plan,
         });
         Ok(())
     }
@@ -490,11 +461,7 @@ impl CoreManager {
         let Active {
             instance,
             forwarder,
-            source_spec,
-            revision,
-            capabilities,
-            runtime_features,
-            ..
+            plan,
         } = active;
         let captured_status = instance.state().borrow().clone();
         abort_and_await(forwarder).await;
@@ -502,9 +469,7 @@ impl CoreManager {
             let epoch = instance.epoch();
             self.inner.publish(
                 instance_core_state(epoch, &captured_status.state),
-                Some(spec_summary(&source_spec, capabilities, runtime_features)),
-                Some(instance.controller().host.clone()),
-                Some(revision),
+                Some(&plan),
             );
             if let Err(error) = instance
                 .stop_and_confirm_dead(self.inner.options.stop_timeout)
@@ -522,12 +487,8 @@ impl CoreManager {
             return Err(Error::NotStarted);
         }
         let epoch = instance.epoch();
-        self.inner.publish(
-            CoreState::Stopping { epoch },
-            Some(spec_summary(&source_spec, capabilities, runtime_features)),
-            Some(instance.controller().host.clone()),
-            Some(revision),
-        );
+        self.inner
+            .publish(CoreState::Stopping { epoch }, Some(&plan));
         if let Err(error) = instance
             .stop_and_confirm_dead(self.inner.options.stop_timeout)
             .await
@@ -546,8 +507,6 @@ impl CoreManager {
             CoreState::Stopped {
                 reason: Some(StopReason::User),
             },
-            None,
-            None,
             None,
         );
         Ok(())
@@ -596,20 +555,12 @@ impl CoreManager {
                 let Active {
                     instance,
                     forwarder,
-                    source_spec,
-                    revision,
-                    capabilities,
-                    runtime_features,
-                    ..
+                    plan,
                 } = active;
                 abort_and_await(forwarder).await;
                 let epoch = instance.epoch();
-                self.inner.publish(
-                    CoreState::Stopping { epoch },
-                    Some(spec_summary(&source_spec, capabilities, runtime_features)),
-                    Some(instance.controller().host.clone()),
-                    Some(revision),
-                );
+                self.inner
+                    .publish(CoreState::Stopping { epoch }, Some(&plan));
                 if let Err(error) = instance
                     .stop_and_confirm_dead(self.inner.options.stop_timeout)
                     .await
@@ -629,8 +580,6 @@ impl CoreManager {
                         reason: Some(StopReason::User),
                     },
                     None,
-                    None,
-                    None,
                 );
             }
             Ok(())
@@ -647,18 +596,13 @@ impl CoreManager {
         self.inner.epoch.fetch_add(1, Ordering::Relaxed) + 1
     }
 
-    async fn spawn_instance(
-        &self,
-        effective_spec: InstanceSpec,
-        epoch: u64,
-        controller: ResolvedController,
-    ) -> Result<Box<dyn RuntimeInstance>, Error> {
+    async fn spawn_instance(&self, plan: &EpochPlan) -> Result<Box<dyn RuntimeInstance>, Error> {
         self.inner
             .backend
             .launch(RuntimeLaunchRequest {
-                effective_spec,
-                epoch,
-                controller,
+                effective_spec: plan.effective_spec.clone(),
+                epoch: plan.revision.epoch,
+                controller: plan.controller.clone(),
                 log_tx: self.inner.log_tx.clone(),
             })
             .await

--- a/crates/nyanpasu-core-manager/src/manager/publish.rs
+++ b/crates/nyanpasu-core-manager/src/manager/publish.rs
@@ -1,32 +1,25 @@
 use crate::{
-    Feature, RuntimeFeature,
     error::Error,
     runtime::RuntimeInstance,
-    spec::InstanceSpec,
     state::{
-        ConfigRevision, CoreState, CoreStatus, HealthStatus, InstanceState, InstanceStatus,
-        SpecSummary, StopReason, now_ms,
+        CoreState, CoreStatus, HealthStatus, InstanceState, InstanceStatus, SpecSummary,
+        StopReason, now_ms,
     },
 };
 
-use super::{Active, CoreManager, Ctrl, Inner};
+use super::{Active, CoreManager, Ctrl, EpochPlan, Inner};
 
 impl Inner {
-    pub(super) fn publish(
-        &self,
-        state: CoreState,
-        spec: Option<SpecSummary>,
-        controller: Option<clash_api::Host>,
-        revision: Option<ConfigRevision>,
-    ) {
+    /// `None` publishes a state with no epoch behind it (stopped, quarantined).
+    pub(super) fn publish(&self, state: CoreState, plan: Option<&EpochPlan>) {
         self.status_tx.send_modify(|status| {
             let lifecycle_changed = status.state != state;
             let health = default_health_for_state(status.health.as_ref(), &state);
             status.state = state;
             status.health = health;
-            status.spec = spec;
-            status.controller = controller;
-            status.revision = revision;
+            status.spec = plan.map(spec_summary);
+            status.controller = plan.map(|plan| plan.controller.host.clone());
+            status.revision = plan.map(|plan| plan.revision.clone());
             if lifecycle_changed {
                 status.changed_at = now_ms();
             }
@@ -34,33 +27,25 @@ impl Inner {
     }
 
     pub(super) fn publish_active(&self, active: &Active, state: CoreState) {
-        self.publish_instance(
-            active.instance.as_ref(),
-            state,
-            &active.source_spec,
-            &active.revision,
-            active.capabilities,
-            active.runtime_features,
-        );
+        self.publish_instance(active.instance.as_ref(), state, &active.plan);
     }
 
+    /// Health and controller still come from the live instance; the epoch's own
+    /// description comes from its plan.
     pub(super) fn publish_instance(
         &self,
         instance: &dyn RuntimeInstance,
         state: CoreState,
-        source_spec: &InstanceSpec,
-        revision: &ConfigRevision,
-        capabilities: enumset::EnumSet<Feature>,
-        runtime_features: enumset::EnumSet<RuntimeFeature>,
+        plan: &EpochPlan,
     ) {
         let health = instance.state().borrow().health.clone();
         self.status_tx.send_modify(|status| {
             let lifecycle_changed = status.state != state;
             status.state = state;
             status.health = health;
-            status.spec = Some(spec_summary(source_spec, capabilities, runtime_features));
+            status.spec = Some(spec_summary(plan));
             status.controller = Some(instance.controller().host.clone());
-            status.revision = Some(revision.clone());
+            status.revision = Some(plan.revision.clone());
             if lifecycle_changed {
                 status.changed_at = now_ms();
             }
@@ -113,16 +98,12 @@ fn apply_epoch_status(status: &mut CoreStatus, epoch: u64, instance: &InstanceSt
     true
 }
 
-pub(super) fn spec_summary(
-    spec: &InstanceSpec,
-    capabilities: enumset::EnumSet<Feature>,
-    runtime_features: enumset::EnumSet<RuntimeFeature>,
-) -> SpecSummary {
+fn spec_summary(plan: &EpochPlan) -> SpecSummary {
     SpecSummary {
-        kind: spec.core.kind,
-        config_path: spec.config_path.clone(),
-        capabilities: capabilities.iter().collect(),
-        runtime_features: runtime_features.iter().collect(),
+        kind: plan.source_spec.core.kind,
+        config_path: plan.source_spec.config_path.clone(),
+        capabilities: plan.capabilities.iter().collect(),
+        runtime_features: plan.runtime_features.iter().collect(),
     }
 }
 
@@ -132,8 +113,6 @@ impl CoreManager {
             CoreState::Stopped {
                 reason: Some(StopReason::Error(error.to_string())),
             },
-            None,
-            None,
             None,
         );
     }

--- a/crates/nyanpasu-core-manager/src/manager/quarantine.rs
+++ b/crates/nyanpasu-core-manager/src/manager/quarantine.rs
@@ -80,7 +80,7 @@ impl CoreManager {
             return Err(error);
         }
         self.inner
-            .publish(CoreState::Stopped { reason: None }, None, None, None);
+            .publish(CoreState::Stopped { reason: None }, None);
         // Every uncertain epoch is now proven dead; nothing may keep holding
         // the DNS override.
         self.dns_restore(&mut ctrl).await;

--- a/crates/nyanpasu-core-manager/src/manager/reconcile.rs
+++ b/crates/nyanpasu-core-manager/src/manager/reconcile.rs
@@ -5,7 +5,7 @@
 
 use crate::{error::Error, spec::InstanceSpec, state::RevisionId};
 
-use super::{ApplyOutcome, CoreManager, abort_and_await, quarantine::reject_quarantine};
+use super::{ApplyOutcome, CoreManager, quarantine::reject_quarantine};
 
 impl CoreManager {
     /// Converges the runtime toward `spec`.
@@ -83,21 +83,7 @@ impl CoreManager {
         }
 
         // Same stale-epoch hygiene as `start`: prove death before reuse.
-        if let Some(stale) = ctrl.current.take() {
-            abort_and_await(stale.forwarder).await;
-            let epoch = stale.instance.epoch();
-            if let Err(error) = stale
-                .instance
-                .stop_and_confirm_dead(self.inner.options.stop_timeout)
-                .await
-            {
-                if matches!(error, Error::StopUnconfirmed(_)) {
-                    return Err(self.latch_quarantine(ctrl, epoch, error));
-                }
-                return Err(error);
-            }
-            self.inner.store.cleanup_epoch(epoch).await?;
-        }
+        self.discard_stale(ctrl).await?;
         self.start_locked(ctrl, spec).await?;
         let revision = ctrl
             .current

--- a/crates/nyanpasu-core-manager/src/manager/reconcile.rs
+++ b/crates/nyanpasu-core-manager/src/manager/reconcile.rs
@@ -103,6 +103,7 @@ impl CoreManager {
             .current
             .as_ref()
             .expect("start_locked installed the active runtime")
+            .plan
             .revision
             .clone();
         Ok(ApplyOutcome::Started { revision })

--- a/crates/nyanpasu-core-manager/src/manager/switching.rs
+++ b/crates/nyanpasu-core-manager/src/manager/switching.rs
@@ -93,7 +93,7 @@ impl CoreManager {
         snapshot: ConfigSnapshot,
         resolved: ResolvedFeatures,
     ) -> Result<(), Error> {
-        let epoch = self.next_epoch();
+        let epoch = ctrl.epochs.next();
         let plan = match self
             .prepare_launch_with_features(&spec, epoch, &snapshot, resolved)
             .await
@@ -143,7 +143,7 @@ impl CoreManager {
         resolved: ResolvedFeatures,
     ) -> Result<SwitchOutcome, Error> {
         let old_epoch = ctrl.current.as_ref().map(|active| active.instance.epoch());
-        let epoch = self.next_epoch();
+        let epoch = ctrl.epochs.next();
         let prepared = match self
             .prepare_graceful(&spec, epoch, &snapshot, resolved)
             .await

--- a/crates/nyanpasu-core-manager/src/manager/switching.rs
+++ b/crates/nyanpasu-core-manager/src/manager/switching.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 use super::{
-    CoreManager, Ctrl, DegradeReason, EpochPlan, PreparedGraceful, SwitchOutcome, abort_and_await,
+    CoreManager, Ctrl, DegradeReason, EpochPlan, PreparedGraceful, RetireFailure, SwitchOutcome,
     quarantine::{record_quarantine, reject_quarantine},
 };
 
@@ -62,21 +62,7 @@ impl CoreManager {
             .as_ref()
             .is_some_and(|active| !active.instance.state().borrow().state.is_terminal());
         if !running {
-            if let Some(stale) = ctrl.current.take() {
-                abort_and_await(stale.forwarder).await;
-                let epoch = stale.instance.epoch();
-                if let Err(error) = stale
-                    .instance
-                    .stop_and_confirm_dead(self.inner.options.stop_timeout)
-                    .await
-                {
-                    if matches!(error, Error::StopUnconfirmed(_)) {
-                        return Err(self.latch_quarantine(ctrl, epoch, error));
-                    }
-                    return Err(error);
-                }
-                self.inner.store.cleanup_epoch(epoch).await?;
-            }
+            self.discard_stale(ctrl).await?;
             self.start_locked(ctrl, spec).await?;
             return Ok(SwitchOutcome::Hard {
                 reason: DegradeReason::NotRunning,
@@ -128,21 +114,20 @@ impl CoreManager {
             Some(&plan),
         );
 
-        let old = ctrl.current.take().expect("running checked by caller");
-        abort_and_await(old.forwarder).await;
-        let old_epoch = old.instance.epoch();
-        if let Err(error) = old
-            .instance
-            .stop_and_confirm_dead(self.inner.options.stop_timeout)
-            .await
-        {
-            let _ = self.inner.store.cleanup_epoch(epoch).await;
-            if matches!(error, Error::StopUnconfirmed(_)) {
-                return Err(self.latch_quarantine(ctrl, old_epoch, error));
+        let old_epoch = match self.retire_current(ctrl).await {
+            Ok(retired) => retired.expect("running checked by caller").revision.epoch,
+            Err(RetireFailure {
+                epoch: retired_epoch,
+                error,
+            }) => {
+                let _ = self.inner.store.cleanup_epoch(epoch).await;
+                if matches!(error, Error::StopUnconfirmed(_)) {
+                    return Err(self.latch_quarantine(ctrl, retired_epoch, error));
+                }
+                self.publish_terminal_error(&error);
+                return Err(error);
             }
-            self.publish_terminal_error(&error);
-            return Err(error);
-        }
+        };
         if let Err(error) = self.inner.store.cleanup_epoch(old_epoch).await {
             self.publish_terminal_error(&error);
             return Err(error);
@@ -212,40 +197,39 @@ impl CoreManager {
             }
         }
 
-        let old = ctrl.current.take().expect("running checked by caller");
-        abort_and_await(old.forwarder).await;
-        let old_epoch = old.instance.epoch();
-        if let Err(error) = old
-            .instance
-            .stop_and_confirm_dead(self.inner.options.stop_timeout)
-            .await
-        {
-            drop(full_staged);
-            let old_uncertain = matches!(error, Error::StopUnconfirmed(_));
-            let old_reason = error.to_string();
-            let new_stop = instance
-                .stop_and_confirm_dead(self.inner.options.stop_timeout)
-                .await;
-            match new_stop {
-                Ok(()) => {
-                    let _ = self.inner.store.cleanup_epoch(epoch).await;
-                    if old_uncertain {
-                        return Err(self.latch_quarantine(ctrl, old_epoch, error));
+        let old_epoch = match self.retire_current(ctrl).await {
+            Ok(retired) => retired.expect("running checked by caller").revision.epoch,
+            Err(RetireFailure {
+                epoch: retired_epoch,
+                error,
+            }) => {
+                drop(full_staged);
+                let old_uncertain = matches!(error, Error::StopUnconfirmed(_));
+                let old_reason = error.to_string();
+                let new_stop = instance
+                    .stop_and_confirm_dead(self.inner.options.stop_timeout)
+                    .await;
+                match new_stop {
+                    Ok(()) => {
+                        let _ = self.inner.store.cleanup_epoch(epoch).await;
+                        if old_uncertain {
+                            return Err(self.latch_quarantine(ctrl, retired_epoch, error));
+                        }
+                        self.publish_terminal_error(&error);
+                        return Err(error);
                     }
-                    self.publish_terminal_error(&error);
-                    return Err(error);
-                }
-                Err(new_error) => {
-                    if old_uncertain {
-                        record_quarantine(ctrl, old_epoch, old_reason);
+                    Err(new_error) => {
+                        if old_uncertain {
+                            record_quarantine(ctrl, retired_epoch, old_reason);
+                        }
+                        let error = Error::StopUnconfirmed(format!(
+                            "old epoch stop failed: {error}; new bootstrap stop also failed: {new_error}"
+                        ));
+                        return Err(self.latch_quarantine(ctrl, epoch, error));
                     }
-                    let error = Error::StopUnconfirmed(format!(
-                        "old epoch stop failed: {error}; new bootstrap stop also failed: {new_error}"
-                    ));
-                    return Err(self.latch_quarantine(ctrl, epoch, error));
                 }
             }
-        }
+        };
 
         let commit = match self.inner.store.commit_replace(full_staged, epoch).await {
             Ok(commit) => commit,

--- a/crates/nyanpasu-core-manager/src/manager/switching.rs
+++ b/crates/nyanpasu-core-manager/src/manager/switching.rs
@@ -14,10 +14,8 @@ use crate::{
 };
 
 use super::{
-    Active, CoreManager, Ctrl, DegradeReason, EpochPlan, PreparedGraceful, SwitchOutcome,
-    abort_and_await,
+    CoreManager, Ctrl, DegradeReason, EpochPlan, PreparedGraceful, SwitchOutcome, abort_and_await,
     quarantine::{record_quarantine, reject_quarantine},
-    spawn_forwarder,
 };
 
 fn graceful_degrade_reason(
@@ -288,7 +286,13 @@ impl CoreManager {
         .await
         .unwrap_or(false);
         if reconciled {
-            self.install_switched(ctrl, instance, launch);
+            let pid = instance.pid().unwrap_or_default();
+            self.inner.publish_instance(
+                instance.as_ref(),
+                CoreState::Running { epoch, pid },
+                &launch,
+            );
+            self.install(ctrl, instance, launch);
             let result = self
                 .inner
                 .store
@@ -322,7 +326,13 @@ impl CoreManager {
                 return with_switch_durability_result(Err(error), durability_warning);
             }
         };
-        self.install_switched(ctrl, replacement, launch);
+        let pid = replacement.pid().unwrap_or_default();
+        self.inner.publish_instance(
+            replacement.as_ref(),
+            CoreState::Running { epoch, pid },
+            &launch,
+        );
+        self.install(ctrl, replacement, launch);
         let result =
             self.inner
                 .store
@@ -332,25 +342,6 @@ impl CoreManager {
                     reason: DegradeReason::PatchFailed,
                 });
         with_switch_durability_result(result, durability_warning)
-    }
-
-    fn install_switched(
-        &self,
-        ctrl: &mut Ctrl,
-        instance: Box<dyn RuntimeInstance>,
-        plan: EpochPlan,
-    ) {
-        let epoch = plan.revision.epoch;
-        let pid = instance.pid().unwrap_or_default();
-        self.inner
-            .publish_instance(instance.as_ref(), CoreState::Running { epoch, pid }, &plan);
-        let forwarder = spawn_forwarder(&self.inner, instance.state(), epoch);
-        ctrl.last_spec = Some(plan.source_spec.clone());
-        ctrl.current = Some(Active {
-            instance,
-            forwarder,
-            plan,
-        });
     }
 
     /// Launchability comes before capability: an unlaunchable kind or missing

--- a/crates/nyanpasu-core-manager/src/manager/switching.rs
+++ b/crates/nyanpasu-core-manager/src/manager/switching.rs
@@ -9,14 +9,13 @@ use crate::{
     kind::CoreKind,
     probe::ProbePhase,
     runtime::RuntimeInstance,
-    spec::{InstanceSpec, ResolvedController},
+    spec::InstanceSpec,
     state::{ConfigRevision, CoreState},
 };
 
 use super::{
-    Active, CoreManager, Ctrl, DegradeReason, PreparedGraceful, PreparedLaunch, SwitchOutcome,
+    Active, CoreManager, Ctrl, DegradeReason, EpochPlan, PreparedGraceful, SwitchOutcome,
     abort_and_await,
-    publish::spec_summary,
     quarantine::{record_quarantine, reject_quarantine},
     spawn_forwarder,
 };
@@ -111,11 +110,11 @@ impl CoreManager {
         resolved: ResolvedFeatures,
     ) -> Result<(), Error> {
         let epoch = self.next_epoch();
-        let prepared = match self
+        let plan = match self
             .prepare_launch_with_features(&spec, epoch, &snapshot, resolved)
             .await
         {
-            Ok(prepared) => prepared,
+            Ok(plan) => plan,
             Err(error) => {
                 let _ = self.inner.store.cleanup_epoch(epoch).await;
                 self.republish_retained(ctrl);
@@ -128,13 +127,7 @@ impl CoreManager {
                 from: old_epoch,
                 to: epoch,
             },
-            Some(spec_summary(
-                &prepared.source_spec,
-                prepared.capabilities,
-                prepared.runtime_features,
-            )),
-            Some(prepared.controller.host.clone()),
-            Some(prepared.revision.clone()),
+            Some(&plan),
         );
 
         let old = ctrl.current.take().expect("running checked by caller");
@@ -156,7 +149,7 @@ impl CoreManager {
             self.publish_terminal_error(&error);
             return Err(error);
         }
-        self.start_prepared(ctrl, prepared).await
+        self.start_prepared(ctrl, plan).await
     }
 
     async fn graceful_switch(
@@ -180,7 +173,7 @@ impl CoreManager {
             }
         };
         let PreparedGraceful {
-            launch,
+            plan: launch,
             full_staged,
             restoration,
         } = prepared;
@@ -189,23 +182,10 @@ impl CoreManager {
                 from: old_epoch,
                 to: epoch,
             },
-            Some(spec_summary(
-                &launch.source_spec,
-                launch.capabilities,
-                launch.runtime_features,
-            )),
-            Some(launch.controller.host.clone()),
-            Some(launch.revision.clone()),
+            Some(&launch),
         );
 
-        let instance = match self
-            .spawn_instance(
-                launch.effective_spec.clone(),
-                epoch,
-                launch.controller.clone(),
-            )
-            .await
-        {
+        let instance = match self.spawn_instance(&launch).await {
             Ok(instance) => instance,
             Err(error) => {
                 drop(full_staged);
@@ -318,8 +298,6 @@ impl CoreManager {
             return with_switch_durability_result(result, durability_warning);
         }
 
-        let effective_spec = launch.effective_spec.clone();
-        let controller = launch.controller.clone();
         if let Err(error) = instance
             .stop_and_confirm_dead(self.inner.options.stop_timeout)
             .await
@@ -332,10 +310,7 @@ impl CoreManager {
             };
             return with_switch_durability_result(Err(error), durability_warning);
         }
-        let replacement = match self
-            .spawn_replacement(effective_spec, epoch, controller)
-            .await
-        {
+        let replacement = match self.spawn_replacement(&launch).await {
             Ok(replacement) => replacement,
             Err(error @ Error::StopUnconfirmed(_)) => {
                 let error = self.latch_quarantine(ctrl, epoch, error);
@@ -363,29 +338,18 @@ impl CoreManager {
         &self,
         ctrl: &mut Ctrl,
         instance: Box<dyn RuntimeInstance>,
-        prepared: PreparedLaunch,
+        plan: EpochPlan,
     ) {
-        let epoch = prepared.revision.epoch;
+        let epoch = plan.revision.epoch;
         let pid = instance.pid().unwrap_or_default();
-        self.inner.publish_instance(
-            instance.as_ref(),
-            CoreState::Running { epoch, pid },
-            &prepared.source_spec,
-            &prepared.revision,
-            prepared.capabilities,
-            prepared.runtime_features,
-        );
+        self.inner
+            .publish_instance(instance.as_ref(), CoreState::Running { epoch, pid }, &plan);
         let forwarder = spawn_forwarder(&self.inner, instance.state(), epoch);
-        ctrl.last_spec = Some(prepared.source_spec.clone());
+        ctrl.last_spec = Some(plan.source_spec.clone());
         ctrl.current = Some(Active {
             instance,
             forwarder,
-            source_spec: prepared.source_spec,
-            revision: prepared.revision,
-            capabilities: prepared.capabilities,
-            runtime_features: prepared.runtime_features,
-            source_document: prepared.source_document,
-            effective_document: prepared.effective_document,
+            plan,
         });
     }
 
@@ -404,7 +368,7 @@ impl CoreManager {
         spec: &InstanceSpec,
         epoch: u64,
         snapshot: &ConfigSnapshot,
-    ) -> Result<PreparedLaunch, Error> {
+    ) -> Result<EpochPlan, Error> {
         self.validate_launchable(spec).await?;
         let resolved = self.resolve_features(&spec.core).await?;
         self.prepare_launch_with_features(spec, epoch, snapshot, resolved)
@@ -417,7 +381,7 @@ impl CoreManager {
         epoch: u64,
         snapshot: &ConfigSnapshot,
         resolved: ResolvedFeatures,
-    ) -> Result<PreparedLaunch, Error> {
+    ) -> Result<EpochPlan, Error> {
         debug_assert_eq!(snapshot.source_path(), spec.config_path);
         let prepared = snapshot.prepare_full(
             self.inner.options.controller_template.as_deref(),
@@ -440,7 +404,7 @@ impl CoreManager {
         let mut effective_spec = spec.clone();
         effective_spec.config_path = runtime_path.clone();
         effective_spec.pid_file = Some(self.inner.store.pid_path(epoch));
-        Ok(PreparedLaunch {
+        Ok(EpochPlan {
             source_spec: spec.clone(),
             effective_spec,
             controller: prepared.controller,
@@ -506,7 +470,7 @@ impl CoreManager {
         effective_spec.config_path = runtime_path.clone();
         effective_spec.pid_file = Some(self.inner.store.pid_path(epoch));
         Ok(PreparedGraceful {
-            launch: PreparedLaunch {
+            plan: EpochPlan {
                 source_spec: spec.clone(),
                 effective_spec,
                 controller: full.controller,
@@ -529,13 +493,9 @@ impl CoreManager {
 
     pub(super) async fn spawn_replacement(
         &self,
-        effective_spec: InstanceSpec,
-        epoch: u64,
-        controller: ResolvedController,
+        plan: &EpochPlan,
     ) -> Result<Box<dyn RuntimeInstance>, Error> {
-        let instance = self
-            .spawn_instance(effective_spec, epoch, controller)
-            .await?;
+        let instance = self.spawn_instance(plan).await?;
         if let Err(error) = instance.wait_ready().await {
             return match instance
                 .stop_and_confirm_dead(self.inner.options.stop_timeout)

--- a/crates/nyanpasu-core-manager/src/runtime/mod.rs
+++ b/crates/nyanpasu-core-manager/src/runtime/mod.rs
@@ -28,6 +28,11 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 /// One live core runtime owned by the orchestrator. Every method mirrors the
 /// surface the orchestrator actually consumes; nothing here promises a PID or
 /// a process — `pid` is `None` for runtimes that have none.
+///
+/// `epoch`, `spec` and `controller` report the [`RuntimeLaunchRequest`] this
+/// runtime was launched from, unchanged. The orchestrator keeps its own copy
+/// of that request as the epoch's plan and relies on the two agreeing when it
+/// relaunches the same epoch on rollback.
 pub trait RuntimeInstance: Send + Sync {
     fn epoch(&self) -> u64;
 

--- a/crates/nyanpasu-core-manager/tests/config_apply.rs
+++ b/crates/nyanpasu-core-manager/tests/config_apply.rs
@@ -446,6 +446,73 @@ async fn failed_desired_restart_restores_and_restarts_the_old_revision() {
 }
 
 #[tokio::test]
+async fn failed_restart_after_an_in_place_apply_rolls_back_to_the_latest_generation() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    // The behavior block is identical in all three configs; changing it would
+    // classify as a switch. `patch-no-effect` keeps the final apply from
+    // reconciling in place, so it falls back to the restart path, and
+    // `allow-lan` makes that replacement fail to start.
+    let behavior = "x-fake-core:\n  patch-no-effect: true\n  fail-start-when-allow-lan: true\n";
+    let first = write_named(&dir, "first.yaml", &http_controller_yaml(port, behavior));
+    let second = write_named(
+        &dir,
+        "second.yaml",
+        &http_controller_yaml(port, &format!("rules:\n  - MATCH,DIRECT\n{behavior}")),
+    );
+    let desired = write_named(
+        &dir,
+        "desired.yaml",
+        &http_controller_yaml(
+            port,
+            &format!("allow-lan: true\nrules:\n  - MATCH,DIRECT\n{behavior}"),
+        ),
+    );
+    let manager = manager(&dir, Duration::from_secs(1)).await;
+    manager.start(spec(&dir, first)).await.expect("start");
+    let (epoch, _) = running(&manager);
+
+    let reloaded = manager
+        .apply_config(spec(&dir, second), None)
+        .await
+        .expect("reload");
+    assert!(
+        matches!(reloaded, ApplyOutcome::Reloaded { .. }),
+        "got {reloaded:?}"
+    );
+    let generation_two = manager.status().revision.expect("reloaded revision");
+    assert_eq!(generation_two.generation, 2);
+
+    let outcome = manager
+        .apply_config(spec(&dir, desired), None)
+        .await
+        .expect("rollback succeeds");
+
+    let ApplyOutcome::RolledBack { revision, .. } = outcome else {
+        panic!("expected RolledBack, got {outcome:?}")
+    };
+    // Not generation 1: the rollback relaunches the whole plan the last
+    // successful in-place apply left behind.
+    assert_eq!(revision, generation_two);
+    let restored: serde_yaml_ng::Mapping =
+        serde_yaml_ng::from_str(&std::fs::read_to_string(&revision.runtime_path).unwrap()).unwrap();
+    assert!(
+        restored
+            .get(serde_yaml_ng::Value::String("rules".into()))
+            .is_some(),
+        "generation 2 was not the restored runtime config"
+    );
+    assert_ne!(
+        restored
+            .get(serde_yaml_ng::Value::String("allow-lan".into()))
+            .and_then(serde_yaml_ng::Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(running(&manager).0, epoch);
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
 async fn desired_and_rollback_commits_preserve_both_durability_warnings() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();

--- a/crates/nyanpasu-core-manager/tests/fake_backend.rs
+++ b/crates/nyanpasu-core-manager/tests/fake_backend.rs
@@ -279,6 +279,13 @@ async fn an_unproven_stop_quarantines_and_blocks_every_mutation() {
         .await
         .unwrap_err();
     assert_eq!(error.kind, Some(CoreErrorKind::StopUnconfirmed));
+    // The switch had already committed a runtime config for its candidate
+    // epoch. That candidate is discarded before the quarantine latch, so an
+    // unprovable stop of the *old* epoch leaves no half-built epoch behind.
+    assert!(
+        !dir.join("runtime").join("config-2.yaml").exists(),
+        "the rejected candidate epoch's runtime config survived the failed switch"
+    );
 
     // No StopProof → no next owner: every further mutation is refused.
     let error = control

--- a/crates/nyanpasu-core-manager/tests/fake_backend.rs
+++ b/crates/nyanpasu-core-manager/tests/fake_backend.rs
@@ -18,7 +18,7 @@ use nyanpasu_core_manager::{
     spec::{InstanceSpec, ResolvedController},
     state::{InstanceState, InstanceStatus, StopReason},
 };
-use tokio::sync::{Notify, watch};
+use tokio::sync::{Notify, broadcast, watch};
 
 #[derive(Default)]
 struct FakeBackend {
@@ -163,6 +163,35 @@ fn reconcile_envelope(dir: &camino::Utf8Path, binary: camino::Utf8PathBuf) -> Co
             expected_applied: None,
         })),
     }
+}
+
+/// The orchestrator treats an epoch's plan as the authority on what that epoch
+/// was launched with, which only holds while instances echo their launch
+/// request verbatim (see [`RuntimeInstance`]).
+#[tokio::test]
+async fn the_fake_instance_echoes_its_launch_request() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let spec = common::mihomo_spec(&dir, dir.join("unused.yaml"));
+    let controller = ResolvedController {
+        host: clash_api::Host::http("127.0.0.1:9090").unwrap(),
+        secret: None,
+    };
+    let (expected_spec, expected_controller) = (format!("{spec:?}"), format!("{controller:?}"));
+    let (log_tx, _) = broadcast::channel(8);
+
+    let instance = FakeBackend::default()
+        .launch(RuntimeLaunchRequest {
+            effective_spec: spec,
+            epoch: 7,
+            controller,
+            log_tx,
+        })
+        .await
+        .expect("launch");
+
+    assert_eq!(instance.epoch(), 7);
+    assert_eq!(format!("{:?}", instance.spec()), expected_spec);
+    assert_eq!(format!("{:?}", instance.controller()), expected_controller);
 }
 
 #[tokio::test]

--- a/crates/nyanpasu-core-manager/tests/instance_lifecycle.rs
+++ b/crates/nyanpasu-core-manager/tests/instance_lifecycle.rs
@@ -33,8 +33,12 @@ async fn start_confirms_via_version_probe() {
         &format!("external-controller: 127.0.0.1:{port}\nx-fake-core:\n  ready-delay-ms: 300\n"),
     );
     let spec = common::mihomo_spec(&dir, config);
+    let controller = http_controller(port);
+    // The orchestrator keeps its own copy of the launch request as the epoch's
+    // plan; the two only stay interchangeable while the instance echoes it.
+    let (expected_spec, expected_controller) = (format!("{spec:?}"), format!("{controller:?}"));
 
-    let instance = Instance::spawn(spec, 1, http_controller(port), CancellationToken::new())
+    let instance = Instance::spawn(spec, 1, controller, CancellationToken::new())
         .await
         .expect("spawn");
     let (recorder, log) = common::record_states(instance.state());
@@ -45,6 +49,8 @@ async fn start_confirms_via_version_probe() {
         InstanceState::Running { pid } if pid > 0
     ));
     assert_eq!(instance.epoch(), 1);
+    assert_eq!(format!("{:?}", instance.spec()), expected_spec);
+    assert_eq!(format!("{:?}", instance.controller()), expected_controller);
 
     instance.stop().await.expect("stop");
     recorder.abort();

--- a/docs/superpowers/specs/2026-07-18-nyanpasu-core-manager-design.md
+++ b/docs/superpowers/specs/2026-07-18-nyanpasu-core-manager-design.md
@@ -259,7 +259,7 @@ impl CoreManager {
 ```
 
 - 控制面方法由一把 async Mutex 串行化;`switch` 进行中到达的控制命令排队等待。
-- **epoch**:`AtomicU64` 自增,0 保留表示"无"。进程内单调即满足路径唯一性(named pipe 随 server 关闭消失;unix socket 残留文件由启动清扫处理)。
+- **epoch**:控制锁内的单调分配器(`EpochAllocator`),由控制面 Mutex 串行化,0 保留表示"无"。进程内单调即满足路径唯一性(named pipe 随 server 关闭消失;unix socket 残留文件由启动清扫处理)。
 - 状态聚合:manager 的转发 task 订阅当前 Instance 的 `watch<InstanceState>`,映射为 `CoreState`(补 epoch)写入对外 watch;切换流程期间由流程直接发布 `Switching`。
 - `stop` 后 manager 保留 last spec(旧实现同语义:stop 后可 restart)。
 


### PR DESCRIPTION
Four commits, one theme: an epoch is one thing, so the manager should hold it as one thing. Pure refactor — no behaviour change, no public API change, no wire change.

## Why

`manager/` described a single epoch's blueprint with three separate structs (`PreparedLaunch`, `PreparedApply`, `Active`) and carried it between them field by field:

- `Active` dropped the two fields it did not need at install time, so a rollback had to scavenge them back off the live instance and clone the other six one at a time.
- An in-place apply copied six fields across by hand. Omitting one of those lines compiles, and leaves `Active` carrying a stale value — the one genuinely silent hole.
- Six call sites spelled out the same "spawn forwarder, retain spec, store `Active`" sequence; seven spelled out the same "take, abort forwarder, prove dead" prefix.
- `Inner.epoch` was an `AtomicU64` named `epoch`, although all four of its call sites already hold the control lock — and `epoch` elsewhere in the module means the identity of a live epoch, not the next number to hand out.

## What

| commit | |
| --- | --- |
| `4094726` | `EpochPlan` carries the whole blueprint from the prepare step into `Active` and back out of it on rollback. The field list survives only in the prepare-step literals, where the compiler demands it in full, so a new per-epoch field has no syntactic place left to be silently forgotten. |
| `6b1800e` | `install` is the only place an epoch enters the slot, and the only `Active` constructor. |
| `48b5481` | `retire_current` owns the shared stop prefix and hands an unprovable stop back as `RetireFailure`; `discard_stale` is the one recovery that repeated verbatim. |
| `56dacc4` | `EpochAllocator` replaces the atomic, inside `Ctrl`, under the lock that already serialised every allocation. |

## Two things this deliberately does *not* simplify

**`install` publishes nothing.** The `Running` publication stays exactly where each caller has it today — before the install in `start` and the graceful switch, after it in the four apply compensations. The status forwarder publishes *without* the control lock, and the daemon bridge forwards every manager transition, so on the install-first paths an instance frame can legitimately reach a subscriber ahead of the orchestrator's own `Running` frame. Which frame arrives first is observable downstream; folding the publication into `install` would have quietly rewritten it on four of the seven paths.

**`retire_current` latches no quarantine.** `hard_switch` and `switch_with_compensation` delete the candidate epoch they had already committed *before* latching, and the latch publishes a terminal state synchronously while the cleanup is asynchronous file work — latching first would expose the quarantine to subscribers while the candidate's artifacts were still on disk. `stop` and `shutdown` keep their own inline sequence for a related reason: both publish between aborting the forwarder and stopping the process.

## Rollback now trusts the plan, not the process

Rollback relaunches from `old_plan.effective_spec` / `old_plan.controller` instead of reading `instance.spec()` / `instance.controller()` back off the process. The two agree: any change to the process spec or to a controller field classifies as `Switch` and never reaches the in-place path, and `config_path`/`pid_file` are derived from the epoch, so they are equal within one. `RuntimeInstance` now states that echo contract explicitly, and a test pins each of its two implementations to it.

## Verification

- `cargo test -p nyanpasu-core-manager --all-features`: 211/0/23 on `main` → **216/0/23** here (+3 guard tests in the first commit, +2 allocator unit tests in the last).
- `cargo clippy -p nyanpasu-core-manager --all-targets --all-features -- -D warnings`, `cargo fmt --check`, and `cargo check -p nyanpasu-service-runtime --all-features`: clean at **each** of the four commits, not only at the tip.
- No `pub` (non-`pub(super)`) signature added or removed in `manager/mod.rs`, `state.rs`, `runtime/mod.rs` or `lib.rs`. `Cargo.toml` and `Cargo.lock` untouched.
- The added tests are guards, not new behaviour: every one of them also passes on `main`.

`compensation_publishes_restart_before_replacement_is_ready` failed once during these runs and passed on rerun and on a clean full rerun. It is a pre-existing timing race in the test itself — it polls a launch counter and then asserts the published state — and is unrelated to these commits: the `Restarting` publication still precedes `spawn_replacement`.

## Merge timing

Draft on purpose. Intended to land **after** rc.2 is tagged, so rc.2 stays a clean bisect point for the v1-wire removal (#394). Nothing here blocks that, and since behaviour is unchanged, waiting one rc costs nothing.

https://claude.ai/code/session_01BsiU6nsZN2i4fcNntm2xZd
