### PR TITLE
refactor(core-manager)!: type the epochs the manager issues

### DIFF
--- a/crates/nyanpasu-core-manager/src/config/mod.rs
+++ b/crates/nyanpasu-core-manager/src/config/mod.rs
@@ -16,7 +16,7 @@ use serde_yaml_ng::{Mapping, Value};
 
 pub(crate) use clash::LOCAL_TRANSPORT_FEATURE;
 
-use crate::{capability::RuntimeFeature, error::Error, spec::ResolvedController};
+use crate::{Epoch, capability::RuntimeFeature, error::Error, spec::ResolvedController};
 
 #[derive(Debug, Clone)]
 pub(crate) struct ConfigSnapshot {
@@ -88,7 +88,7 @@ impl ConfigSnapshot {
         &self,
         controller_template: Option<&str>,
         runtime_dir: &Utf8Path,
-        epoch: u64,
+        epoch: Epoch,
         runtime: EnumSet<RuntimeFeature>,
     ) -> Result<PreparedConfig, Error> {
         self.prepare(controller_template, runtime_dir, epoch, runtime, false)
@@ -98,7 +98,7 @@ impl ConfigSnapshot {
         &self,
         controller_template: Option<&str>,
         runtime_dir: &Utf8Path,
-        epoch: u64,
+        epoch: Epoch,
         runtime: EnumSet<RuntimeFeature>,
     ) -> Result<PreparedConfig, Error> {
         self.prepare(controller_template, runtime_dir, epoch, runtime, true)
@@ -108,7 +108,7 @@ impl ConfigSnapshot {
         &self,
         controller_template: Option<&str>,
         runtime_dir: &Utf8Path,
-        epoch: u64,
+        epoch: Epoch,
         runtime: EnumSet<RuntimeFeature>,
         zero_inbounds: bool,
     ) -> Result<PreparedConfig, Error> {
@@ -232,7 +232,30 @@ pub(crate) fn validate_controller_template(template: Option<&str>) -> Result<(),
     Ok(())
 }
 
+/// Manager construction validates the controller template before any epoch
+/// exists. A template may put `{epoch}` in a parent component, and the
+/// rendered parent is canonicalized and checked for containment, so which
+/// number renders is observable: `runtime/0/` and `runtime/1/` need not both
+/// exist, nor resolve through the same symlink. Zero therefore stays the probe
+/// rendering it has always been — a number, never promoted to an `Epoch`.
+const TEMPLATE_PROBE_RENDERING: u64 = 0;
+
+pub(crate) fn validate_managed_endpoint(
+    runtime_dir: &Utf8Path,
+    template: Option<&str>,
+) -> Result<(), Error> {
+    render_endpoint_path(runtime_dir, template, TEMPLATE_PROBE_RENDERING).map(|_| ())
+}
+
 pub(crate) fn managed_endpoint_path(
+    runtime_dir: &Utf8Path,
+    template: Option<&str>,
+    epoch: Epoch,
+) -> Result<String, Error> {
+    render_endpoint_path(runtime_dir, template, epoch.get())
+}
+
+fn render_endpoint_path(
     runtime_dir: &Utf8Path,
     template: Option<&str>,
     epoch: u64,
@@ -289,6 +312,7 @@ fn managed_unix_endpoint(runtime_dir: &Utf8Path, endpoint: &str) -> Result<Strin
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::epoch::epoch;
 
     fn snapshot(yaml: &str) -> ConfigSnapshot {
         ConfigSnapshot::from_bytes(Utf8PathBuf::from("config.yaml"), yaml.as_bytes()).unwrap()
@@ -312,7 +336,7 @@ mod tests {
         let source = snapshot("external-controller-unix: /tmp/source.sock");
 
         let error = source
-            .prepare_full(None, Utf8Path::new("runtime"), 1, EnumSet::new())
+            .prepare_full(None, Utf8Path::new("runtime"), epoch(1), EnumSet::new())
             .unwrap_err();
 
         assert!(matches!(error, Error::ControllerMissing));
@@ -344,7 +368,7 @@ mod tests {
             .prepare_bootstrap(
                 Some(r"\\.\pipe\ny-{epoch}"),
                 Utf8Path::new("runtime"),
-                7,
+                epoch(7),
                 EnumSet::only(RuntimeFeature::LocalIpc),
             )
             .unwrap();
@@ -374,13 +398,17 @@ mod tests {
     #[test]
     fn endpoint_template_requires_and_substitutes_epoch() {
         let dir = Utf8Path::new("/tmp/x");
-        assert!(managed_endpoint_path(dir, Some("fixed"), 1).is_err());
+        assert!(managed_endpoint_path(dir, Some("fixed"), epoch(1)).is_err());
         #[cfg(windows)]
         assert_eq!(
-            managed_endpoint_path(dir, Some(r"\\.\pipe\ny-{epoch}"), 42).unwrap(),
+            managed_endpoint_path(dir, Some(r"\\.\pipe\ny-{epoch}"), epoch(42)).unwrap(),
             r"\\.\pipe\ny-42"
         );
-        assert!(managed_endpoint_path(dir, None, 42).unwrap().contains("42"));
+        assert!(
+            managed_endpoint_path(dir, None, epoch(42))
+                .unwrap()
+                .contains("42")
+        );
     }
 
     #[cfg(unix)]
@@ -389,10 +417,10 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let runtime = Utf8PathBuf::from_path_buf(root.path().join("runtime")).unwrap();
         std::fs::create_dir(&runtime).unwrap();
-        assert!(managed_endpoint_path(&runtime, Some("core-{epoch}.sock"), 4).is_ok());
+        assert!(managed_endpoint_path(&runtime, Some("core-{epoch}.sock"), epoch(4)).is_ok());
         let outside = root.path().join("escaped-{epoch}.sock");
         let outside = outside.to_str().unwrap();
-        let error = managed_endpoint_path(&runtime, Some(outside), 4).unwrap_err();
+        let error = managed_endpoint_path(&runtime, Some(outside), epoch(4)).unwrap_err();
         assert!(error.to_string().contains("escapes runtime directory"));
     }
 
@@ -410,7 +438,7 @@ mod tests {
         let runtime = Utf8PathBuf::from_path_buf(runtime.canonicalize().unwrap()).unwrap();
         let template = runtime.join("link/core-{epoch}.sock");
 
-        let error = managed_endpoint_path(&runtime, Some(template.as_str()), 5).unwrap_err();
+        let error = managed_endpoint_path(&runtime, Some(template.as_str()), epoch(5)).unwrap_err();
         assert!(error.to_string().contains("escapes runtime directory"));
     }
 }

--- a/crates/nyanpasu-core-manager/src/config/runtime_store.rs
+++ b/crates/nyanpasu-core-manager/src/config/runtime_store.rs
@@ -9,7 +9,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_utils::io::atomic_fs;
 use tokio::io::AsyncWriteExt;
 
-use crate::Error;
+use crate::{Epoch, Error};
 
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -48,7 +48,7 @@ impl Drop for StagedRuntimeConfig {
 #[derive(Debug, Clone)]
 pub struct RuntimeConfigBackup {
     path: Utf8PathBuf,
-    epoch: u64,
+    epoch: Epoch,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -124,16 +124,32 @@ impl RuntimeConfigStore {
         &self.dir
     }
 
-    pub fn runtime_path(&self, epoch: u64) -> Utf8PathBuf {
-        self.dir.join(format!("config-{epoch}.yaml"))
+    pub fn runtime_path(&self, epoch: Epoch) -> Utf8PathBuf {
+        self.artifact_runtime_path(epoch.get())
     }
 
-    pub fn pid_path(&self, epoch: u64) -> Utf8PathBuf {
-        self.dir.join(format!("core-{epoch}.pid"))
+    pub fn pid_path(&self, epoch: Epoch) -> Utf8PathBuf {
+        self.artifact_pid_path(epoch.get())
     }
 
-    pub fn socket_path(&self, epoch: u64) -> Utf8PathBuf {
-        self.dir.join(format!("core-{epoch}.sock"))
+    pub fn socket_path(&self, epoch: Epoch) -> Utf8PathBuf {
+        self.artifact_socket_path(epoch.get())
+    }
+
+    // Artifact naming keyed by a number recovered from a filename rather than
+    // by a live epoch. Only the orphan sweep holds such a number: a directory
+    // can carry `config-0.yaml` from an interrupted write, and a zero that
+    // cannot be named is a zero that leaks forever.
+    fn artifact_runtime_path(&self, discovered: u64) -> Utf8PathBuf {
+        self.dir.join(format!("config-{discovered}.yaml"))
+    }
+
+    pub(crate) fn artifact_pid_path(&self, discovered: u64) -> Utf8PathBuf {
+        self.dir.join(format!("core-{discovered}.pid"))
+    }
+
+    fn artifact_socket_path(&self, discovered: u64) -> Utf8PathBuf {
+        self.dir.join(format!("core-{discovered}.sock"))
     }
 
     #[cfg(feature = "test-hooks")]
@@ -149,7 +165,7 @@ impl RuntimeConfigStore {
             .map_err(std::io::Error::other)?
     }
 
-    pub async fn stage(&self, epoch: u64, contents: &[u8]) -> Result<StagedRuntimeConfig, Error> {
+    pub async fn stage(&self, epoch: Epoch, contents: &[u8]) -> Result<StagedRuntimeConfig, Error> {
         let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
         let path = self.dir.join(format!(
             ".config-{epoch}.yaml.tmp-{}-{counter}",
@@ -194,7 +210,7 @@ impl RuntimeConfigStore {
     pub async fn commit_new(
         &self,
         mut staged: StagedRuntimeConfig,
-        epoch: u64,
+        epoch: Epoch,
     ) -> Result<Utf8PathBuf, Error> {
         self.validate_staged(&staged, epoch).await?;
         let target = self.runtime_path(epoch);
@@ -205,7 +221,11 @@ impl RuntimeConfigStore {
         Ok(target)
     }
 
-    pub async fn replace(&self, epoch: u64, contents: &[u8]) -> Result<RuntimeConfigCommit, Error> {
+    pub async fn replace(
+        &self,
+        epoch: Epoch,
+        contents: &[u8],
+    ) -> Result<RuntimeConfigCommit, Error> {
         let staged = self.stage(epoch, contents).await?;
         self.commit_replace(staged, epoch).await
     }
@@ -216,7 +236,7 @@ impl RuntimeConfigStore {
     pub async fn commit_replace(
         &self,
         mut staged: StagedRuntimeConfig,
-        epoch: u64,
+        epoch: Epoch,
     ) -> Result<RuntimeConfigCommit, Error> {
         self.validate_staged(&staged, epoch).await?;
         let target = self.runtime_path(epoch);
@@ -243,7 +263,11 @@ impl RuntimeConfigStore {
         Ok(installed_commit(target, parent_sync))
     }
 
-    pub async fn backup(&self, epoch: u64, generation: u64) -> Result<RuntimeConfigBackup, Error> {
+    pub async fn backup(
+        &self,
+        epoch: Epoch,
+        generation: u64,
+    ) -> Result<RuntimeConfigBackup, Error> {
         let target = self.runtime_path(epoch);
         atomic_fs::validate_existing_regular_target(&target).await?;
         let contents = tokio::fs::read(&target).await?;
@@ -276,15 +300,24 @@ impl RuntimeConfigStore {
             .map_err(Error::from)
     }
 
-    pub async fn cleanup_epoch(&self, epoch: u64) -> Result<(), Error> {
-        for path in [self.runtime_path(epoch), self.pid_path(epoch)] {
+    pub async fn cleanup_epoch(&self, epoch: Epoch) -> Result<(), Error> {
+        self.cleanup_artifacts(epoch.get()).await
+    }
+
+    /// Removes every artifact named for `discovered`, which the orphan sweep
+    /// reads back from filenames and therefore cannot vouch for as an epoch.
+    pub(crate) async fn cleanup_artifacts(&self, discovered: u64) -> Result<(), Error> {
+        for path in [
+            self.artifact_runtime_path(discovered),
+            self.artifact_pid_path(discovered),
+        ] {
             atomic_fs::remove_regular_file(&path).await?;
         }
-        remove_socket_artifact(&self.socket_path(epoch)).await?;
+        remove_socket_artifact(&self.artifact_socket_path(discovered)).await?;
 
-        let prefix = format!("config-{epoch}.yaml.backup-");
-        let temp_prefix = format!(".config-{epoch}.yaml.tmp-");
-        let pid_temp_prefix = format!("core-{epoch}.pid.tmp-");
+        let prefix = format!("config-{discovered}.yaml.backup-");
+        let temp_prefix = format!(".config-{discovered}.yaml.tmp-");
+        let pid_temp_prefix = format!("core-{discovered}.pid.tmp-");
         let mut entries = tokio::fs::read_dir(&self.dir).await?;
         while let Some(entry) = entries.next_entry().await? {
             let name = entry.file_name();
@@ -320,7 +353,11 @@ impl RuntimeConfigStore {
         Ok(epochs)
     }
 
-    async fn validate_staged(&self, staged: &StagedRuntimeConfig, epoch: u64) -> Result<(), Error> {
+    async fn validate_staged(
+        &self,
+        staged: &StagedRuntimeConfig,
+        epoch: Epoch,
+    ) -> Result<(), Error> {
         if staged.path.parent() != Some(self.dir.as_path())
             || !staged
                 .path
@@ -415,6 +452,7 @@ async fn remove_socket_artifact(path: &Utf8Path) -> Result<(), Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::epoch::epoch;
 
     fn temp_store_dir() -> (tempfile::TempDir, Utf8PathBuf) {
         let dir = tempfile::tempdir().unwrap();
@@ -428,8 +466,8 @@ mod tests {
         let store = RuntimeConfigStore::new(dir).await.unwrap();
         let old = b"marker: old\npayload: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n";
         let new = b"marker: new\npayload: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n";
-        let staged = store.stage(7, old).await.unwrap();
-        let path = store.commit_new(staged, 7).await.unwrap();
+        let staged = store.stage(epoch(7), old).await.unwrap();
+        let path = store.commit_new(staged, epoch(7)).await.unwrap();
 
         let mut readers = Vec::new();
         for _ in 0..8 {
@@ -459,7 +497,7 @@ mod tests {
         }
         for round in 0..100 {
             store
-                .replace(7, if round % 2 == 0 { new } else { old })
+                .replace(epoch(7), if round % 2 == 0 { new } else { old })
                 .await
                 .unwrap();
         }
@@ -472,17 +510,17 @@ mod tests {
     async fn backup_restore_and_cleanup_preserve_complete_versions() {
         let (_guard, dir) = temp_store_dir();
         let store = RuntimeConfigStore::new(dir).await.unwrap();
-        let staged = store.stage(3, b"value: old\n").await.unwrap();
-        let path = store.commit_new(staged, 3).await.unwrap();
-        let backup = store.backup(3, 1).await.unwrap();
-        store.replace(3, b"value: new\n").await.unwrap();
+        let staged = store.stage(epoch(3), b"value: old\n").await.unwrap();
+        let path = store.commit_new(staged, epoch(3)).await.unwrap();
+        let backup = store.backup(epoch(3), 1).await.unwrap();
+        store.replace(epoch(3), b"value: new\n").await.unwrap();
         store.restore(&backup).await.unwrap();
         assert_eq!(
             tokio::fs::read_to_string(&path).await.unwrap(),
             "value: old\n"
         );
         store.remove_backup(backup).await.unwrap();
-        store.cleanup_epoch(3).await.unwrap();
+        store.cleanup_epoch(epoch(3)).await.unwrap();
         assert!(!path.exists());
     }
 
@@ -493,7 +531,7 @@ mod tests {
 
         let (_guard, dir) = temp_store_dir();
         let store = RuntimeConfigStore::new(dir).await.unwrap();
-        let socket_path = store.socket_path(9);
+        let socket_path = store.socket_path(epoch(9));
         let listener = UnixListener::bind(&socket_path).unwrap();
         assert!(
             std::fs::symlink_metadata(&socket_path)
@@ -503,7 +541,7 @@ mod tests {
         );
         drop(listener);
 
-        store.cleanup_epoch(9).await.unwrap();
+        store.cleanup_epoch(epoch(9)).await.unwrap();
         assert!(!socket_path.exists());
     }
 

--- a/crates/nyanpasu-core-manager/src/dns.rs
+++ b/crates/nyanpasu-core-manager/src/dns.rs
@@ -16,7 +16,7 @@
 use serde::{Deserialize, Serialize};
 use serde_yaml_ng::Mapping;
 
-use crate::runtime::BoxFuture;
+use crate::{Epoch, runtime::BoxFuture};
 
 /// The override one host should hold while a given effective config runs.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -90,7 +90,7 @@ pub trait DnsController: Send + Sync {
     fn apply<'a>(
         &'a self,
         intent: &'a DnsIntent,
-        runtime_epoch: u64,
+        runtime_epoch: Epoch,
     ) -> BoxFuture<'a, Result<DnsOverrideRecord, DnsError>>;
 
     /// Restores `record.previous` and reads the result back. Also the orphan
@@ -195,7 +195,7 @@ pub mod macos {
         fn apply<'a>(
             &'a self,
             intent: &'a DnsIntent,
-            runtime_epoch: u64,
+            runtime_epoch: Epoch,
         ) -> BoxFuture<'a, Result<DnsOverrideRecord, DnsError>> {
             Box::pin(async move {
                 let previous = self.read_back().await?.unwrap_or_default();
@@ -215,7 +215,7 @@ pub mod macos {
                     interface: self.store_key.clone(),
                     previous,
                     applied: intent.servers.clone(),
-                    runtime_epoch,
+                    runtime_epoch: runtime_epoch.get(),
                     owner_generation: None,
                     state: DnsOverrideState::Applied,
                 })

--- a/crates/nyanpasu-core-manager/src/epoch.rs
+++ b/crates/nyanpasu-core-manager/src/epoch.rs
@@ -1,0 +1,52 @@
+//! The manager's epoch identifier.
+
+use std::{
+    fmt,
+    num::{NonZeroU64, TryFromIntError},
+};
+
+/// One epoch issued by the manager's allocator.
+///
+/// Never zero: allocation starts at 1 and "no epoch" is spelled
+/// `Option<Epoch>`, never a zero sentinel. Deliberately not convertible from a
+/// bare `u64` — a number decoded from an artifact filename, a pid record, or
+/// the wire is not an epoch until something vouches for it. Cross that
+/// boundary with [`Epoch::try_from`] inbound and [`Epoch::get`] outbound.
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Epoch(NonZeroU64);
+
+impl Epoch {
+    pub const fn new(value: u64) -> Option<Self> {
+        match NonZeroU64::new(value) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+impl TryFrom<u64> for Epoch {
+    type Error = TryFromIntError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        NonZeroU64::try_from(value).map(Self)
+    }
+}
+
+impl fmt::Display for Epoch {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+#[cfg(test)]
+pub(crate) const fn epoch(value: u64) -> Epoch {
+    match Epoch::new(value) {
+        Some(epoch) => epoch,
+        None => panic!("a test epoch must be nonzero"),
+    }
+}

--- a/crates/nyanpasu-core-manager/src/error.rs
+++ b/crates/nyanpasu-core-manager/src/error.rs
@@ -1,7 +1,7 @@
 use camino::Utf8PathBuf;
 pub use nyanpasu_core_metadata::CoreErrorKind;
 
-use crate::{kind::CoreKind, state::RevisionId};
+use crate::{Epoch, kind::CoreKind, state::RevisionId};
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -40,7 +40,7 @@ pub enum Error {
     #[error("core process death could not be confirmed: {0}")]
     StopUnconfirmed(String),
     #[error("manager is quarantined by uncertain epoch {epoch}: {reason}")]
-    ManagerQuarantined { epoch: u64, reason: String },
+    ManagerQuarantined { epoch: Epoch, reason: String },
     #[error("config revision conflict: expected {expected}, actual {actual:?}")]
     RevisionConflict {
         expected: RevisionId,
@@ -137,6 +137,7 @@ fn utf8_lossy(path: std::path::PathBuf) -> Utf8PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::epoch::epoch;
 
     #[test]
     fn manager_errors_carry_their_wire_kind() {
@@ -146,7 +147,7 @@ mod tests {
             (
                 Error::RevisionConflict {
                     expected: RevisionId {
-                        epoch: 3,
+                        epoch: epoch(3),
                         generation: 7,
                         effective_hash: "fedcba9876543210".to_owned(),
                     },
@@ -156,7 +157,7 @@ mod tests {
             ),
             (
                 Error::ManagerQuarantined {
-                    epoch: 3,
+                    epoch: epoch(3),
                     reason: "death unconfirmed".to_owned(),
                 },
                 Some(CoreErrorKind::Quarantined),
@@ -203,7 +204,7 @@ mod tests {
             source: Box::new(Error::DurabilityUncertain {
                 source: Box::new(Error::RevisionConflict {
                     expected: RevisionId {
-                        epoch: 3,
+                        epoch: epoch(3),
                         generation: 7,
                         effective_hash: "fedcba9876543210".to_owned(),
                     },

--- a/crates/nyanpasu-core-manager/src/health/driver.rs
+++ b/crates/nyanpasu-core-manager/src/health/driver.rs
@@ -4,6 +4,7 @@ use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
+    epoch::Epoch,
     health::HealthPolicy,
     probe::{ProbeContext, ProbeHandle, ProbePhase, ProbeResult},
     spec::ResolvedController,
@@ -35,7 +36,7 @@ pub(crate) struct ProbeDriver {
 impl ProbeDriver {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn start(
-        epoch: u64,
+        epoch: Epoch,
         run_id: u64,
         pid: u32,
         controller: Arc<ResolvedController>,
@@ -133,7 +134,7 @@ impl Drop for ProbeDriver {
 #[allow(clippy::too_many_arguments)]
 async fn run_attempt(
     probe: &ProbeHandle,
-    epoch: u64,
+    epoch: Epoch,
     run_id: u64,
     pid: u32,
     phase: ProbePhase,
@@ -179,6 +180,7 @@ async fn run_attempt(
 
 #[cfg(test)]
 mod tests {
+    use crate::epoch::epoch;
     use std::{
         future::Future,
         pin::Pin,
@@ -239,7 +241,7 @@ mod tests {
         });
         let (observation_tx, mut observation_rx) = mpsc::unbounded_channel();
         let driver = ProbeDriver::start(
-            1,
+            epoch(1),
             1,
             10,
             controller(),
@@ -326,7 +328,7 @@ mod tests {
         );
         let (observation_tx, mut observation_rx) = mpsc::unbounded_channel();
         let driver = ProbeDriver::start(
-            1,
+            epoch(1),
             1,
             10,
             controller(),
@@ -359,7 +361,7 @@ mod tests {
         );
         let (observation_tx, mut observation_rx) = mpsc::unbounded_channel();
         let driver = ProbeDriver::start(
-            1,
+            epoch(1),
             1,
             10,
             controller(),
@@ -400,7 +402,7 @@ mod tests {
         });
         let (tx, _rx) = mpsc::unbounded_channel();
         let first = ProbeDriver::start(
-            1,
+            epoch(1),
             1,
             10,
             controller(),
@@ -410,7 +412,7 @@ mod tests {
             tx.clone(),
         );
         let second = ProbeDriver::start(
-            2,
+            epoch(2),
             1,
             20,
             controller(),

--- a/crates/nyanpasu-core-manager/src/health/probe.rs
+++ b/crates/nyanpasu-core-manager/src/health/probe.rs
@@ -4,7 +4,7 @@ use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 
 use tokio_util::sync::CancellationToken;
 
-use crate::{Error, ResolvedController};
+use crate::{Epoch, Error, ResolvedController};
 
 /// The boxed future returned by an object-safe [`HealthProbe`].
 pub type ProbeFuture<'a> = Pin<Box<dyn Future<Output = ProbeResult> + Send + 'a>>;
@@ -36,7 +36,7 @@ pub enum ProbePhase {
 /// may carry an authentication secret.
 #[derive(Clone)]
 pub struct ProbeContext {
-    pub epoch: u64,
+    pub epoch: Epoch,
     pub pid: u32,
     pub phase: ProbePhase,
     pub controller: Arc<ResolvedController>,
@@ -140,6 +140,7 @@ impl HealthProbe for ControllerVersionProbe {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::epoch::epoch;
 
     fn controller(port: u16) -> ResolvedController {
         ResolvedController {
@@ -150,7 +151,7 @@ mod tests {
 
     fn context(controller: ResolvedController) -> ProbeContext {
         ProbeContext {
-            epoch: 1,
+            epoch: epoch(1),
             pid: 1,
             phase: ProbePhase::Readiness,
             controller: Arc::new(controller),

--- a/crates/nyanpasu-core-manager/src/instance.rs
+++ b/crates/nyanpasu-core-manager/src/instance.rs
@@ -19,6 +19,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 
 use crate::{
+    epoch::Epoch,
     error::Error,
     health::{
         HealthTracker, TrackerState,
@@ -39,7 +40,7 @@ const LOG_TAIL_FRAMES: usize = 32;
 /// One epoch of a running core. The spec is immutable; a config change means a
 /// new `Instance` with a new epoch (created by `CoreManager`).
 pub struct Instance {
-    epoch: u64,
+    epoch: Epoch,
     spec: Arc<InstanceSpec>,
     controller: Arc<ResolvedController>,
     state_rx: watch::Receiver<InstanceStatus>,
@@ -136,7 +137,7 @@ struct ProbeNowRequest {
 
 pub struct InstanceBuilder {
     spec: InstanceSpec,
-    epoch: u64,
+    epoch: Epoch,
     controller: ResolvedController,
     parent: CancellationToken,
     readiness_probe: Option<ProbeHandle>,
@@ -148,7 +149,7 @@ pub struct InstanceBuilder {
 impl Instance {
     pub fn builder(
         spec: InstanceSpec,
-        epoch: u64,
+        epoch: Epoch,
         controller: ResolvedController,
         parent: CancellationToken,
     ) -> InstanceBuilder {
@@ -166,7 +167,7 @@ impl Instance {
 
     pub async fn spawn(
         spec: InstanceSpec,
-        epoch: u64,
+        epoch: Epoch,
         controller: ResolvedController,
         parent: CancellationToken,
     ) -> Result<Instance, Error> {
@@ -215,7 +216,7 @@ impl Instance {
             state_tx,
             user_stop: AtomicBool::new(false),
             probe_timeout: AtomicBool::new(false),
-            parser: parking_lot::Mutex::new(LogParser::new(spec.core.kind, epoch)),
+            parser: parking_lot::Mutex::new(LogParser::new(spec.core.kind, epoch.get())),
             log_tail: parking_lot::Mutex::new(VecDeque::with_capacity(LOG_TAIL_FRAMES)),
             log_tx: log_tx.unwrap_or_else(|| broadcast::channel(LOG_CHANNEL_CAPACITY).0),
             cancel: cancel.clone(),
@@ -290,7 +291,7 @@ impl Instance {
         self.shared.log_tx.subscribe()
     }
 
-    pub fn epoch(&self) -> u64 {
+    pub fn epoch(&self) -> Epoch {
         self.epoch
     }
 
@@ -499,7 +500,7 @@ impl Drop for Instance {
     }
 }
 
-fn build_command(spec: &InstanceSpec, epoch: u64, controller: &ResolvedController) -> Command {
+fn build_command(spec: &InstanceSpec, epoch: Epoch, controller: &ResolvedController) -> Command {
     let mut args = kind::run_args(spec.core.kind, &spec.working_dir, &spec.config_path)
         .expect("kind validated in Instance::spawn");
     args.extend(kind::controller_args(spec.core.kind, &controller.host));
@@ -519,7 +520,7 @@ fn build_command(spec: &InstanceSpec, epoch: u64, controller: &ResolvedControlle
         command = if epoch_pid_path(spec, epoch).is_some() {
             command.epoch_pid_file(EpochPidFile::new(
                 pid_file.as_std_path(),
-                epoch,
+                epoch.get(),
                 spec.config_path.as_std_path(),
             ))
         } else {
@@ -529,7 +530,7 @@ fn build_command(spec: &InstanceSpec, epoch: u64, controller: &ResolvedControlle
     command
 }
 
-fn epoch_pid_path(spec: &InstanceSpec, epoch: u64) -> Option<&camino::Utf8Path> {
+fn epoch_pid_path(spec: &InstanceSpec, epoch: Epoch) -> Option<&camino::Utf8Path> {
     let pid_file = spec.pid_file.as_deref()?;
     let expected_pid = format!("core-{epoch}.pid");
     let expected_config = format!("config-{epoch}.yaml");
@@ -551,7 +552,7 @@ struct RunState {
 async fn monitor_loop(
     mut events: mpsc::UnboundedReceiver<SupervisorEvent>,
     shared: Arc<Shared>,
-    epoch: u64,
+    epoch: Epoch,
     options: InstanceOptions,
     controller: Arc<ResolvedController>,
     readiness_probe: ProbeHandle,
@@ -739,7 +740,7 @@ async fn apply_probe_observation(
     initial_deadline: Instant,
     shared: &Shared,
     driver: Option<&ProbeDriver>,
-    epoch: u64,
+    epoch: Epoch,
 ) -> bool {
     let Some(run) = current.as_mut() else {
         return false;
@@ -756,7 +757,7 @@ async fn apply_probe_observation(
     }
 
     tracing::trace!(
-        epoch,
+        epoch = epoch.get(),
         run_id = observation.run_id,
         pid = observation.pid,
         phase = ?observation.phase,
@@ -811,7 +812,7 @@ async fn drain_probe_observations(
     initial_deadline: Instant,
     shared: &Shared,
     driver: Option<&ProbeDriver>,
-    epoch: u64,
+    epoch: Epoch,
 ) -> bool {
     while let Ok(observation) = observations.try_recv() {
         let became_ready = apply_probe_observation(
@@ -901,6 +902,7 @@ fn publish_terminal(shared: &Shared, last_exit: Option<&TerminatedPayload>) {
 
 #[cfg(test)]
 mod tests {
+    use crate::epoch::epoch;
     use std::time::Duration;
 
     use super::*;
@@ -1072,7 +1074,7 @@ mod tests {
                 initial_deadline,
                 &shared,
                 None,
-                1,
+                epoch(1),
             )
             .await
         );

--- a/crates/nyanpasu-core-manager/src/lib.rs
+++ b/crates/nyanpasu-core-manager/src/lib.rs
@@ -7,6 +7,7 @@ mod capability;
 mod config;
 pub mod control;
 pub mod dns;
+mod epoch;
 mod error;
 mod health;
 pub mod instance;
@@ -27,6 +28,7 @@ pub use control::{
     ReconcileRequest, payload_digest,
 };
 pub use dns::{DnsController, DnsError, DnsIntent, DnsOverrideRecord, DnsOverrideState};
+pub use epoch::Epoch;
 pub use error::{CoreErrorKind, Error};
 pub use health::{HealthPolicy, probe};
 pub use instance::{Instance, InstanceBuilder};

--- a/crates/nyanpasu-core-manager/src/manager/dns_sync.rs
+++ b/crates/nyanpasu-core-manager/src/manager/dns_sync.rs
@@ -121,7 +121,7 @@ impl CoreManager {
                 .as_ref()
                 .map_or_else(Vec::new, |(_, previous)| previous.clone()),
             applied: intent.servers.clone(),
-            runtime_epoch: epoch,
+            runtime_epoch: epoch.get(),
             owner_generation: None,
             state: DnsOverrideState::Applied,
         };

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -15,7 +15,7 @@ use serde_yaml_ng::Mapping;
 use tokio::sync::{broadcast, watch};
 
 use crate::{
-    Feature, RuntimeFeature,
+    Epoch, Feature, RuntimeFeature,
     capability::{ResolvedFeatures, VersionCache},
     config::{self, ConfigSnapshot, mihomo},
     dns::{DnsController, DnsOverrideRecord},
@@ -167,15 +167,15 @@ impl EpochAllocator {
         Self { last: max_seen }
     }
 
-    fn next(&mut self) -> u64 {
+    fn next(&mut self) -> Epoch {
         self.last = self.last.checked_add(1).expect("epoch space exhausted");
-        self.last
+        Epoch::new(self.last).expect("a checked increment cannot produce zero")
     }
 }
 
 #[derive(Debug, Clone)]
 struct QuarantinedEpoch {
-    epoch: u64,
+    epoch: Epoch,
     reason: String,
     death_proven: bool,
 }
@@ -207,7 +207,7 @@ struct Active {
 /// latch quarantine — differs per transaction and stays with the caller, in the
 /// order that caller already has.
 struct RetireFailure {
-    epoch: u64,
+    epoch: Epoch,
     error: Error,
 }
 
@@ -292,7 +292,7 @@ impl CoreManager {
         // endpoint is a configuration error whether or not this core ends up
         // selecting local IPC, and construction is the caller's last chance to
         // fix it.
-        config::managed_endpoint_path(store.dir(), options.controller_template.as_deref(), 0)?;
+        config::validate_managed_endpoint(store.dir(), options.controller_template.as_deref())?;
         for (name, timeout) in [
             ("control_timeout", options.control_timeout),
             ("reconcile_timeout", options.reconcile_timeout),
@@ -690,7 +690,7 @@ async fn abort_and_await(mut forwarder: tokio::task::JoinHandle<()>) {
 fn spawn_forwarder(
     inner: &Arc<Inner>,
     mut state_rx: watch::Receiver<InstanceStatus>,
-    epoch: u64,
+    epoch: Epoch,
 ) -> tokio::task::JoinHandle<()> {
     let inner = Arc::downgrade(inner);
     tokio::spawn(async move {
@@ -711,13 +711,14 @@ fn spawn_forwarder(
 #[cfg(test)]
 mod tests {
     use super::EpochAllocator;
+    use crate::epoch::epoch;
 
     #[test]
     fn epochs_are_monotone_past_the_seed_and_never_zero() {
         let mut fresh = EpochAllocator::seeded(0);
-        assert_eq!(fresh.next(), 1);
+        assert_eq!(fresh.next(), epoch(1));
         let mut seeded = EpochAllocator::seeded(7);
-        assert_eq!((seeded.next(), seeded.next()), (8, 9));
+        assert_eq!((seeded.next(), seeded.next()), (epoch(8), epoch(9)));
     }
 
     #[test]

--- a/crates/nyanpasu-core-manager/src/manager/publish.rs
+++ b/crates/nyanpasu-core-manager/src/manager/publish.rs
@@ -1,4 +1,5 @@
 use crate::{
+    epoch::Epoch,
     error::Error,
     runtime::RuntimeInstance,
     state::{
@@ -52,7 +53,7 @@ impl Inner {
         });
     }
 
-    pub(super) fn publish_epoch_status(&self, epoch: u64, instance: InstanceStatus) {
+    pub(super) fn publish_epoch_status(&self, epoch: Epoch, instance: InstanceStatus) {
         self.status_tx
             .send_if_modified(|status| apply_epoch_status(status, epoch, &instance));
     }
@@ -80,7 +81,7 @@ fn default_health_for_state(
     Some(health)
 }
 
-fn apply_epoch_status(status: &mut CoreStatus, epoch: u64, instance: &InstanceStatus) -> bool {
+fn apply_epoch_status(status: &mut CoreStatus, epoch: Epoch, instance: &InstanceStatus) -> bool {
     if status.revision.as_ref().map(|revision| revision.epoch) != Some(epoch) {
         return false;
     }
@@ -129,7 +130,7 @@ impl CoreManager {
     }
 }
 
-pub(super) fn instance_core_state(epoch: u64, state: &InstanceState) -> CoreState {
+pub(super) fn instance_core_state(epoch: Epoch, state: &InstanceState) -> CoreState {
     match state {
         InstanceState::Starting => CoreState::Starting { epoch },
         InstanceState::Running { pid } => CoreState::Running { epoch, pid: *pid },
@@ -146,6 +147,7 @@ pub(super) fn instance_core_state(epoch: u64, state: &InstanceState) -> CoreStat
 
 #[cfg(test)]
 mod tests {
+    use crate::epoch::epoch;
     use tokio::sync::watch;
 
     use super::*;
@@ -155,17 +157,23 @@ mod tests {
     fn old_epoch_events_cannot_overwrite_new_epoch_status() {
         let mut status = CoreStatus::initial();
         status.revision = Some(ConfigRevision {
-            epoch: 9,
+            epoch: epoch(9),
             generation: 1,
             source_hash: "source".into(),
             effective_hash: "effective".into(),
             runtime_path: "config-9.yaml".into(),
         });
-        status.state = CoreState::Running { epoch: 9, pid: 90 };
+        status.state = CoreState::Running {
+            epoch: epoch(9),
+            pid: 90,
+        };
         for stale in [
-            CoreState::Running { epoch: 8, pid: 80 },
+            CoreState::Running {
+                epoch: epoch(8),
+                pid: 80,
+            },
             CoreState::Restarting {
-                epoch: 8,
+                epoch: epoch(8),
                 attempt: 2,
             },
             CoreState::Stopped {
@@ -183,10 +191,10 @@ mod tests {
                 },
                 health: None,
             };
-            assert!(!apply_epoch_status(&mut status, 8, &stale_status));
+            assert!(!apply_epoch_status(&mut status, epoch(8), &stale_status));
             assert!(matches!(
                 status.state,
-                CoreState::Running { epoch: 9, pid: 90 }
+                CoreState::Running { epoch: observed, pid: 90 } if observed == epoch(9)
             ));
         }
     }
@@ -195,26 +203,29 @@ mod tests {
     fn stale_epoch_status_neither_mutates_nor_wakes_watchers() {
         let mut status = CoreStatus::initial();
         status.revision = Some(ConfigRevision {
-            epoch: 9,
+            epoch: epoch(9),
             generation: 1,
             source_hash: "source".into(),
             effective_hash: "effective".into(),
             runtime_path: "config-9.yaml".into(),
         });
-        status.state = CoreState::Running { epoch: 9, pid: 90 };
+        status.state = CoreState::Running {
+            epoch: epoch(9),
+            pid: 90,
+        };
         let (tx, rx) = watch::channel(status);
         let stale = InstanceStatus {
             state: InstanceState::Running { pid: 80 },
             health: Some(HealthStatus::starting()),
         };
 
-        let sent = tx.send_if_modified(|status| apply_epoch_status(status, 8, &stale));
+        let sent = tx.send_if_modified(|status| apply_epoch_status(status, epoch(8), &stale));
 
         assert!(!sent);
         assert!(!rx.has_changed().unwrap());
         assert!(matches!(
             rx.borrow().state,
-            CoreState::Running { epoch: 9, pid: 90 }
+            CoreState::Running { epoch: observed, pid: 90 } if observed == epoch(9)
         ));
     }
 
@@ -222,13 +233,16 @@ mod tests {
     fn pure_health_transition_preserves_lifecycle_changed_at() {
         let mut status = CoreStatus::initial();
         status.revision = Some(ConfigRevision {
-            epoch: 3,
+            epoch: epoch(3),
             generation: 1,
             source_hash: "source".into(),
             effective_hash: "effective".into(),
             runtime_path: "config-3.yaml".into(),
         });
-        status.state = CoreState::Running { epoch: 3, pid: 30 };
+        status.state = CoreState::Running {
+            epoch: epoch(3),
+            pid: 30,
+        };
         status.changed_at = 7;
         let mut health = HealthStatus::starting();
         health.state = crate::state::HealthState::Unhealthy;
@@ -237,7 +251,7 @@ mod tests {
             health: Some(health.clone()),
         };
 
-        assert!(apply_epoch_status(&mut status, 3, &instance));
+        assert!(apply_epoch_status(&mut status, epoch(3), &instance));
         assert_eq!(status.changed_at, 7);
         assert_eq!(status.health, Some(health));
     }

--- a/crates/nyanpasu-core-manager/src/manager/quarantine.rs
+++ b/crates/nyanpasu-core-manager/src/manager/quarantine.rs
@@ -1,11 +1,11 @@
 use nyanpasu_utils::process::{OrphanReapOutcome, reap_epoch_pid_file};
 
-use crate::{error::Error, runtime_store::RuntimeConfigStore, state::CoreState};
+use crate::{Epoch, error::Error, runtime_store::RuntimeConfigStore, state::CoreState};
 
 use super::{CoreManager, Ctrl, QuarantinedEpoch};
 
 impl CoreManager {
-    pub(super) fn latch_quarantine(&self, ctrl: &mut Ctrl, epoch: u64, error: Error) -> Error {
+    pub(super) fn latch_quarantine(&self, ctrl: &mut Ctrl, epoch: Epoch, error: Error) -> Error {
         record_quarantine(ctrl, epoch, error.to_string());
         let quarantine = quarantine_error(ctrl).expect("quarantine was just inserted");
         self.publish_terminal_error(&quarantine);
@@ -68,11 +68,13 @@ impl CoreManager {
             }
         }
         if !failures.is_empty() {
+            // Every failure arm above leaves its entry in place: the retain
+            // that removes an entry runs only after its cleanup succeeded.
             let first_epoch = ctrl
                 .quarantine
                 .first()
                 .map(|entry| entry.epoch)
-                .unwrap_or_default();
+                .expect("a failed recovery leaves its epoch quarantined");
             let error = Error::ManagerQuarantined {
                 epoch: first_epoch,
                 reason: failures.join(" | "),
@@ -107,7 +109,7 @@ fn quarantine_error(ctrl: &Ctrl) -> Option<Error> {
     })
 }
 
-pub(super) fn record_quarantine(ctrl: &mut Ctrl, epoch: u64, reason: String) {
+pub(super) fn record_quarantine(ctrl: &mut Ctrl, epoch: Epoch, reason: String) {
     if let Some(existing) = ctrl
         .quarantine
         .iter_mut()
@@ -131,14 +133,18 @@ pub(super) fn reject_quarantine(ctrl: &Ctrl) -> Result<(), Error> {
 }
 
 pub(super) async fn sweep_orphans(store: &RuntimeConfigStore) -> Result<u64, Error> {
-    let epochs = store.artifact_epochs().await?;
-    let max_epoch = epochs.iter().copied().max().unwrap_or(0);
-    for epoch in epochs {
-        let pid_path = store.pid_path(epoch);
+    // Artifact numbers are read back from filenames, so they are not epochs:
+    // a directory can carry `config-0.yaml`, and a zero that cannot be named
+    // is a zero that leaks forever. Discovery and cleanup stay raw; only the
+    // allocator seed crosses into the domain, one increment later.
+    let discovered = store.artifact_epochs().await?;
+    let max_seen = discovered.iter().copied().max().unwrap_or(0);
+    for artifact in discovered {
+        let pid_path = store.artifact_pid_path(artifact);
         if tokio::fs::try_exists(&pid_path).await? {
             reap_epoch_pid_file(pid_path.as_std_path(), store.dir().as_std_path()).await?;
         }
-        store.cleanup_epoch(epoch).await?;
+        store.cleanup_artifacts(artifact).await?;
     }
-    Ok(max_epoch)
+    Ok(max_seen)
 }

--- a/crates/nyanpasu-core-manager/src/manager/switching.rs
+++ b/crates/nyanpasu-core-manager/src/manager/switching.rs
@@ -1,5 +1,5 @@
 use crate::{
-    RuntimeFeature,
+    Epoch, RuntimeFeature,
     capability::ResolvedFeatures,
     config::{
         ConfigSnapshot,
@@ -341,7 +341,7 @@ impl CoreManager {
     pub(super) async fn prepare_launch(
         &self,
         spec: &InstanceSpec,
-        epoch: u64,
+        epoch: Epoch,
         snapshot: &ConfigSnapshot,
     ) -> Result<EpochPlan, Error> {
         self.validate_launchable(spec).await?;
@@ -353,7 +353,7 @@ impl CoreManager {
     async fn prepare_launch_with_features(
         &self,
         spec: &InstanceSpec,
-        epoch: u64,
+        epoch: Epoch,
         snapshot: &ConfigSnapshot,
         resolved: ResolvedFeatures,
     ) -> Result<EpochPlan, Error> {
@@ -400,7 +400,7 @@ impl CoreManager {
     async fn prepare_graceful(
         &self,
         spec: &InstanceSpec,
-        epoch: u64,
+        epoch: Epoch,
         snapshot: &ConfigSnapshot,
         resolved: ResolvedFeatures,
     ) -> Result<PreparedGraceful, Error> {

--- a/crates/nyanpasu-core-manager/src/runtime/mod.rs
+++ b/crates/nyanpasu-core-manager/src/runtime/mod.rs
@@ -14,6 +14,7 @@ use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 use tokio::sync::{broadcast, watch};
 
 use crate::{
+    epoch::Epoch,
     error::Error,
     log::LogFrame,
     probe::{ProbePhase, ProbeResult},
@@ -34,7 +35,7 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 /// of that request as the epoch's plan and relies on the two agreeing when it
 /// relaunches the same epoch on rollback.
 pub trait RuntimeInstance: Send + Sync {
-    fn epoch(&self) -> u64;
+    fn epoch(&self) -> Epoch;
 
     fn spec(&self) -> &InstanceSpec;
 
@@ -67,7 +68,7 @@ pub trait RuntimeInstance: Send + Sync {
 /// every epoch.
 pub struct RuntimeLaunchRequest {
     pub effective_spec: InstanceSpec,
-    pub epoch: u64,
+    pub epoch: Epoch,
     pub controller: ResolvedController,
     pub log_tx: broadcast::Sender<Arc<LogFrame>>,
 }

--- a/crates/nyanpasu-core-manager/src/runtime/process.rs
+++ b/crates/nyanpasu-core-manager/src/runtime/process.rs
@@ -7,6 +7,7 @@ use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
+    epoch::Epoch,
     error::Error,
     instance::Instance,
     probe::{ProbeHandle, ProbePhase, ProbeResult},
@@ -74,7 +75,7 @@ impl RuntimeBackend for ProcessRuntimeBackend {
 }
 
 impl RuntimeInstance for Instance {
-    fn epoch(&self) -> u64 {
+    fn epoch(&self) -> Epoch {
         Instance::epoch(self)
     }
 

--- a/crates/nyanpasu-core-manager/src/state.rs
+++ b/crates/nyanpasu-core-manager/src/state.rs
@@ -2,7 +2,7 @@
 
 use camino::Utf8PathBuf;
 
-use crate::{Feature, RuntimeFeature, kind::CoreKind};
+use crate::{Epoch, Feature, RuntimeFeature, kind::CoreKind};
 
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -110,23 +110,23 @@ pub enum CoreState {
         reason: Option<StopReason>,
     },
     Starting {
-        epoch: u64,
+        epoch: Epoch,
     },
     Running {
-        epoch: u64,
+        epoch: Epoch,
         pid: u32,
     },
     Restarting {
-        epoch: u64,
+        epoch: Epoch,
         attempt: u32,
     },
     /// A hard or graceful switch is in flight.
     Switching {
-        from: Option<u64>,
-        to: u64,
+        from: Option<Epoch>,
+        to: Epoch,
     },
     Stopping {
-        epoch: u64,
+        epoch: Epoch,
     },
 }
 
@@ -142,7 +142,7 @@ pub struct SpecSummary {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConfigRevision {
-    pub epoch: u64,
+    pub epoch: Epoch,
     pub generation: u64,
     pub source_hash: String,
     pub effective_hash: String,
@@ -151,7 +151,7 @@ pub struct ConfigRevision {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RevisionId {
-    pub epoch: u64,
+    pub epoch: Epoch,
     pub generation: u64,
     pub effective_hash: String,
 }

--- a/crates/nyanpasu-core-manager/tests/common/mod.rs
+++ b/crates/nyanpasu-core-manager/tests/common/mod.rs
@@ -8,12 +8,20 @@ use std::{sync::Arc, time::Duration};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_core_manager::{
-    CoreKind, CoreSpec, HealthPolicy, InstanceOptions, InstanceSpec,
+    CoreKind, CoreSpec, Epoch, HealthPolicy, InstanceOptions, InstanceSpec,
     state::{HealthState, InstanceState, InstanceStatus},
 };
 use nyanpasu_utils::process::{Backoff, RestartPolicy};
 use parking_lot::Mutex;
 use tokio::sync::watch;
+
+/// The epoch a test means when it writes a number. Deliberately not a
+/// `From<u64>` on the type itself: production code must keep paying the
+/// nonzero check at every boundary, and a test that skips it stops exercising
+/// the barrier it is meant to prove.
+pub fn epoch(value: u64) -> Epoch {
+    Epoch::new(value).expect("a test epoch must be nonzero")
+}
 
 pub fn fake_core_bin() -> Utf8PathBuf {
     Utf8PathBuf::from(env!("CARGO_BIN_EXE_nyanpasu-fake-core"))

--- a/crates/nyanpasu-core-manager/tests/config_apply.rs
+++ b/crates/nyanpasu-core-manager/tests/config_apply.rs
@@ -10,8 +10,8 @@ use std::{
 };
 
 use nyanpasu_core_manager::{
-    ApplyOutcome, ControllerVersionProbe, CoreManager, CoreState, Error, HealthProbe, InstanceSpec,
-    LocalIpcPolicy, ManagerOptions, ProbeHandle, ProbePhase, ProbeResult, RevisionId,
+    ApplyOutcome, ControllerVersionProbe, CoreManager, CoreState, Epoch, Error, HealthProbe,
+    InstanceSpec, LocalIpcPolicy, ManagerOptions, ProbeHandle, ProbePhase, ProbeResult, RevisionId,
 };
 use parking_lot::Mutex;
 
@@ -32,7 +32,7 @@ fn write_named(dir: &camino::Utf8Path, name: &str, body: &str) -> camino::Utf8Pa
     path
 }
 
-fn running(manager: &CoreManager) -> (u64, u32) {
+fn running(manager: &CoreManager) -> (Epoch, u32) {
     match manager.status().state {
         CoreState::Running { epoch, pid } => (epoch, pid),
         state => panic!("expected running, got {state:?}"),
@@ -61,13 +61,13 @@ async fn custom_probe_plan_reaches_desired_replacement_and_rollback() {
         "probe-desired.yaml",
         &http_controller_yaml(port, "x-setting: desired\n"),
     );
-    let attempts = Arc::new(Mutex::new(Vec::<(u64, u32)>::new()));
+    let attempts = Arc::new(Mutex::new(Vec::<(Epoch, u32)>::new()));
     let readiness = ProbeHandle::from_fn("recorded-readiness", {
         let attempts = attempts.clone();
         move |context| {
             attempts.lock().push((context.epoch, context.pid));
             async move {
-                if context.epoch == 2 {
+                if context.epoch == common::epoch(2) {
                     return ProbeResult::Unhealthy {
                         detail: Some("reject desired epoch".into()),
                     };
@@ -100,11 +100,11 @@ async fn custom_probe_plan_reaches_desired_replacement_and_rollback() {
         (
             attempts
                 .iter()
-                .filter_map(|(epoch, pid)| (*epoch == 1).then_some(*pid))
+                .filter_map(|(observed, pid)| (*observed == common::epoch(1)).then_some(*pid))
                 .collect(),
             attempts
                 .iter()
-                .filter_map(|(epoch, pid)| (*epoch == 2).then_some(*pid))
+                .filter_map(|(observed, pid)| (*observed == common::epoch(2)).then_some(*pid))
                 .collect(),
         )
     };
@@ -646,11 +646,11 @@ async fn patch_success_with_get_mismatch_restarts_desired() {
 #[test]
 fn revision_id_is_an_explicit_cas_token() {
     let token = RevisionId {
-        epoch: 4,
+        epoch: common::epoch(4),
         generation: 8,
         effective_hash: "hash".into(),
     };
-    assert_eq!(token.epoch, 4);
+    assert_eq!(token.epoch, common::epoch(4));
 }
 
 #[tokio::test]

--- a/crates/nyanpasu-core-manager/tests/control_plane.rs
+++ b/crates/nyanpasu-core-manager/tests/control_plane.rs
@@ -140,7 +140,8 @@ async fn an_idempotent_resubmit_attaches_to_the_original_operation() {
         panic!("expected a cold start, got {first:?}");
     };
     assert_eq!(
-        revision.epoch, 1,
+        revision.epoch,
+        common::epoch(1),
         "a second start would have bumped the epoch"
     );
 

--- a/crates/nyanpasu-core-manager/tests/dns_override.rs
+++ b/crates/nyanpasu-core-manager/tests/dns_override.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use nyanpasu_core_manager::{
-    CoreState, Error, ManagerOptions, RevisionId,
+    CoreState, Epoch, Error, ManagerOptions, RevisionId,
     dns::{DnsController, DnsError, DnsIntent, DnsOverrideRecord, DnsOverrideState},
     manager::{ApplyOutcome, CoreManager},
     runtime::BoxFuture,
@@ -25,7 +25,7 @@ use tokio::sync::Notify;
 /// with the original resolver would prove the baseline was kept even when the
 /// orchestrator overwrote it.
 struct FakeDns {
-    applied: Mutex<Vec<(DnsIntent, u64)>>,
+    applied: Mutex<Vec<(DnsIntent, Epoch)>>,
     restored: Mutex<Vec<DnsOverrideRecord>>,
     /// What the interface currently resolves through.
     current: Mutex<Vec<String>>,
@@ -62,7 +62,7 @@ impl DnsController for FakeDns {
     fn apply<'a>(
         &'a self,
         intent: &'a DnsIntent,
-        runtime_epoch: u64,
+        runtime_epoch: Epoch,
     ) -> BoxFuture<'a, Result<DnsOverrideRecord, DnsError>> {
         Box::pin(async move {
             if self.hang_apply.load(Ordering::SeqCst) {
@@ -81,7 +81,7 @@ impl DnsController for FakeDns {
                 interface: "Wi-Fi".to_owned(),
                 previous,
                 applied: intent.servers.clone(),
-                runtime_epoch,
+                runtime_epoch: runtime_epoch.get(),
                 owner_generation: None,
                 state: DnsOverrideState::Applied,
             })
@@ -149,13 +149,22 @@ async fn reconcile_applies_the_override_and_stop_restores_it_first() {
         let applied = dns.applied.lock().unwrap();
         assert_eq!(applied.len(), 1, "start tail applies exactly once");
         assert_eq!(applied[0].0.servers, vec!["198.18.0.2".to_owned()]);
-        assert_eq!(applied[0].1, 1, "the record names the running epoch");
+        assert_eq!(
+            applied[0].1,
+            common::epoch(1),
+            "the record names the running epoch"
+        );
     }
     // The record survived to disk with the controller's read-back data.
-    let record: DnsOverrideRecord =
-        serde_json::from_slice(&std::fs::read(record_path(&dir)).unwrap()).unwrap();
+    let raw = std::fs::read(record_path(&dir)).unwrap();
+    let record: DnsOverrideRecord = serde_json::from_slice(&raw).unwrap();
     assert_eq!(record.state, DnsOverrideState::Applied);
     assert_eq!(record.previous, vec!["10.0.0.1".to_owned()]);
+    // The persisted epoch is a bare number, not a wrapper object or a string:
+    // `Epoch` stops at this boundary so an older record stays readable and a
+    // future validation policy cannot turn one into a load failure.
+    let json: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+    assert_eq!(json["runtime_epoch"], serde_json::json!(1));
 
     manager.stop().await.unwrap();
     {
@@ -431,7 +440,7 @@ async fn a_revision_conflict_never_touches_dns() {
     let before = std::fs::read(record_path(&dir)).unwrap();
 
     let stale = RevisionId {
-        epoch: 99,
+        epoch: common::epoch(99),
         generation: 99,
         effective_hash: "deadbeef".to_owned(),
     };

--- a/crates/nyanpasu-core-manager/tests/fake_backend.rs
+++ b/crates/nyanpasu-core-manager/tests/fake_backend.rs
@@ -11,8 +11,8 @@ use std::sync::{
 
 use nyanpasu_core_manager::{
     ConfigInput, ControlOptions, CoreCommand, CoreCommandEnvelope, CoreControl, CoreErrorKind,
-    Error, ManagerOptions, OperationId, OperationOutput, OperationState, ProbePhase, ProbeResult,
-    ReconcileRequest,
+    Epoch, Error, ManagerOptions, OperationId, OperationOutput, OperationState, ProbePhase,
+    ProbeResult, ReconcileRequest,
     manager::{ApplyOutcome, CoreManager},
     runtime::{BoxFuture, RuntimeBackend, RuntimeInstance, RuntimeLaunchRequest},
     spec::{InstanceSpec, ResolvedController},
@@ -23,7 +23,7 @@ use tokio::sync::{Notify, broadcast, watch};
 #[derive(Default)]
 struct FakeBackend {
     refuse_stop: Arc<AtomicBool>,
-    launched_epochs: Mutex<Vec<u64>>,
+    launched_epochs: Mutex<Vec<Epoch>>,
     /// Holds the first launch inside the executor so a test can fill the queue
     /// behind a transaction that is provably running.
     gate_launch: AtomicBool,
@@ -73,14 +73,14 @@ impl RuntimeBackend for FakeBackend {
 
 struct FakeInstance {
     spec: InstanceSpec,
-    epoch: u64,
+    epoch: Epoch,
     controller: ResolvedController,
     state_tx: watch::Sender<InstanceStatus>,
     refuse_stop: Arc<AtomicBool>,
 }
 
 impl RuntimeInstance for FakeInstance {
-    fn epoch(&self) -> u64 {
+    fn epoch(&self) -> Epoch {
         self.epoch
     }
 
@@ -182,14 +182,14 @@ async fn the_fake_instance_echoes_its_launch_request() {
     let instance = FakeBackend::default()
         .launch(RuntimeLaunchRequest {
             effective_spec: spec,
-            epoch: 7,
+            epoch: common::epoch(7),
             controller,
             log_tx,
         })
         .await
         .expect("launch");
 
-    assert_eq!(instance.epoch(), 7);
+    assert_eq!(instance.epoch(), common::epoch(7));
     assert_eq!(format!("{:?}", instance.spec()), expected_spec);
     assert_eq!(format!("{:?}", instance.controller()), expected_controller);
 }
@@ -230,7 +230,10 @@ async fn the_whole_lifecycle_runs_without_a_single_process() {
         ),
         "expected a switch, got {output:?}"
     );
-    assert_eq!(*backend.launched_epochs.lock().unwrap(), vec![1, 2]);
+    assert_eq!(
+        *backend.launched_epochs.lock().unwrap(),
+        vec![common::epoch(1), common::epoch(2)]
+    );
 
     let output = control
         .submit(CoreCommandEnvelope {

--- a/crates/nyanpasu-core-manager/tests/graceful_switch.rs
+++ b/crates/nyanpasu-core-manager/tests/graceful_switch.rs
@@ -3,7 +3,7 @@ mod common;
 use std::time::Duration;
 
 use nyanpasu_core_manager::{
-    ControllerVersionProbe, CoreState, DegradeReason, Error, HealthProbe, LocalIpcPolicy,
+    ControllerVersionProbe, CoreState, DegradeReason, Epoch, Error, HealthProbe, LocalIpcPolicy,
     ManagerOptions, ProbeHandle, ProbeResult, StopReason, manager::CoreManager,
 };
 
@@ -225,7 +225,7 @@ async fn graceful_switch_overlaps_and_restores_listeners() {
     let CoreState::Running { epoch, .. } = status.state else {
         panic!("not running after switch")
     };
-    assert_eq!(epoch, 2);
+    assert_eq!(epoch, common::epoch(2));
     assert_eq!(
         status
             .spec
@@ -235,7 +235,7 @@ async fn graceful_switch_overlaps_and_restores_listeners() {
     );
     assert_eq!(
         status.revision.as_ref().map(|revision| revision.epoch),
-        Some(2)
+        Some(common::epoch(2))
     );
     assert!(status.controller.is_some());
     assert!(
@@ -312,7 +312,7 @@ async fn graceful_respawn_loads_the_full_committed_runtime_config() {
     else {
         panic!("new core is not running")
     };
-    assert_eq!(epoch, 2);
+    assert_eq!(epoch, common::epoch(2));
     nyanpasu_utils::os::kill_pid::<String>(first_pid, None)
         .await
         .expect("kill new core process");
@@ -320,7 +320,8 @@ async fn graceful_respawn_loads_the_full_committed_runtime_config() {
     let second_pid = tokio::time::timeout(Duration::from_secs(10), async {
         loop {
             let state = status_rx.borrow_and_update().state.clone();
-            if let CoreState::Running { epoch: 2, pid } = state
+            if let CoreState::Running { epoch, pid } = state
+                && epoch == common::epoch(2)
                 && pid != first_pid
             {
                 break pid;
@@ -396,9 +397,9 @@ async fn graceful_success_publishes_only_the_new_epoch_context() {
     );
     assert_eq!(
         status.revision.as_ref().map(|revision| revision.epoch),
-        Some(2)
+        Some(common::epoch(2))
     );
-    assert!(matches!(status.state, CoreState::Running { epoch: 2, .. }));
+    assert!(matches!(status.state, CoreState::Running { epoch, .. } if epoch == common::epoch(2)));
     for status in observed.lock().iter() {
         let published_epoch = match status.state {
             CoreState::Running { epoch, .. }
@@ -409,11 +410,11 @@ async fn graceful_success_publishes_only_the_new_epoch_context() {
             CoreState::Stopped { .. } => None,
             _ => None,
         };
-        if published_epoch == Some(2) {
+        if published_epoch == Some(common::epoch(2)) {
             assert_eq!(status.controller.as_ref(), Some(&new_controller));
             assert_eq!(
                 status.revision.as_ref().map(|revision| revision.epoch),
-                Some(2)
+                Some(common::epoch(2))
             );
         }
     }
@@ -462,7 +463,7 @@ async fn graceful_patch_timeout_with_matching_get_is_success() {
     let CoreState::Running { epoch, pid } = manager.status().state else {
         panic!("new core is not running")
     };
-    assert_eq!(epoch, 2);
+    assert_eq!(epoch, common::epoch(2));
     assert_ne!(pid, before_pid);
     tokio::net::TcpStream::connect(("127.0.0.1", mixed))
         .await
@@ -706,7 +707,7 @@ async fn hard_switch_removes_the_old_runtime_config() {
     assert!(runtime_dir.join("config-2.yaml").exists());
     assert!(matches!(
         manager.status().state,
-        CoreState::Running { epoch: 2, .. }
+        CoreState::Running { epoch, .. } if epoch == common::epoch(2)
     ));
     manager.shutdown().await.expect("shutdown");
 }
@@ -751,7 +752,7 @@ async fn prefer_http_fallback_degrades_switch_to_hard() {
     );
     assert!(matches!(
         manager.status().state,
-        CoreState::Running { epoch: 2, .. }
+        CoreState::Running { epoch, .. } if epoch == common::epoch(2)
     ));
     assert!(matches!(
         manager.status().controller,
@@ -928,7 +929,7 @@ async fn rejected_patch_falls_back_to_a_hard_restart() {
     )
     .unwrap();
 
-    let attempts = Arc::new(Mutex::new(Vec::<(u64, u32)>::new()));
+    let attempts = Arc::new(Mutex::new(Vec::<(Epoch, u32)>::new()));
     let readiness = ProbeHandle::from_fn("graceful-recorded-readiness", {
         let attempts = attempts.clone();
         move |context| {
@@ -980,11 +981,11 @@ async fn rejected_patch_falls_back_to_a_hard_restart() {
         (
             attempts
                 .iter()
-                .filter_map(|(epoch, pid)| (*epoch == 1).then_some(*pid))
+                .filter_map(|(observed, pid)| (*observed == common::epoch(1)).then_some(*pid))
                 .collect(),
             attempts
                 .iter()
-                .filter_map(|(epoch, pid)| (*epoch == 2).then_some(*pid))
+                .filter_map(|(observed, pid)| (*observed == common::epoch(2)).then_some(*pid))
                 .collect(),
         )
     };

--- a/crates/nyanpasu-core-manager/tests/instance_lifecycle.rs
+++ b/crates/nyanpasu-core-manager/tests/instance_lifecycle.rs
@@ -38,7 +38,7 @@ async fn start_confirms_via_version_probe() {
     // plan; the two only stay interchangeable while the instance echoes it.
     let (expected_spec, expected_controller) = (format!("{spec:?}"), format!("{controller:?}"));
 
-    let instance = Instance::spawn(spec, 1, controller, CancellationToken::new())
+    let instance = Instance::spawn(spec, common::epoch(1), controller, CancellationToken::new())
         .await
         .expect("spawn");
     let (recorder, log) = common::record_states(instance.state());
@@ -48,7 +48,7 @@ async fn start_confirms_via_version_probe() {
         instance.state().borrow().state,
         InstanceState::Running { pid } if pid > 0
     ));
-    assert_eq!(instance.epoch(), 1);
+    assert_eq!(instance.epoch(), common::epoch(1));
     assert_eq!(format!("{:?}", instance.spec()), expected_spec);
     assert_eq!(format!("{:?}", instance.controller()), expected_controller);
 
@@ -75,9 +75,14 @@ async fn dropping_an_instance_kills_the_core() {
     let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
     let spec = common::mihomo_spec(&dir, config);
 
-    let instance = Instance::spawn(spec, 1, http_controller(port), CancellationToken::new())
-        .await
-        .expect("spawn");
+    let instance = Instance::spawn(
+        spec,
+        common::epoch(1),
+        http_controller(port),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("spawn");
     instance.wait_ready().await.expect("healthy");
     drop(instance);
     common::wait_port_refused(port).await;
@@ -94,9 +99,14 @@ async fn startup_timeout_kills_the_core() {
     let mut spec = common::mihomo_spec(&dir, config);
     spec.options.startup_timeout = std::time::Duration::from_secs(1);
 
-    let instance = Instance::spawn(spec, 1, http_controller(port), CancellationToken::new())
-        .await
-        .expect("spawn");
+    let instance = Instance::spawn(
+        spec,
+        common::epoch(1),
+        http_controller(port),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("spawn");
     let err = instance.wait_ready().await.expect_err("must time out");
     assert!(
         matches!(err, nyanpasu_core_manager::Error::StartupTimeout { .. }),
@@ -121,9 +131,14 @@ async fn immediate_exit_reports_stderr_tail() {
     spec.options.restart_policy =
         nyanpasu_utils::process::RestartPolicy::OnFailure { max_restarts: 1 };
 
-    let instance = Instance::spawn(spec, 1, http_controller(port), CancellationToken::new())
-        .await
-        .expect("spawn succeeds; the failure is the exit");
+    let instance = Instance::spawn(
+        spec,
+        common::epoch(1),
+        http_controller(port),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("spawn succeeds; the failure is the exit");
     let err = instance.wait_ready().await.expect_err("must fail");
     match err {
         nyanpasu_core_manager::Error::StartupFailed { stderr_tail } => {
@@ -152,9 +167,14 @@ async fn immediate_exit_reports_a_stdout_fatal() {
     spec.options.restart_policy =
         nyanpasu_utils::process::RestartPolicy::OnFailure { max_restarts: 1 };
 
-    let instance = Instance::spawn(spec, 1, http_controller(port), CancellationToken::new())
-        .await
-        .expect("spawn succeeds; the failure is the exit");
+    let instance = Instance::spawn(
+        spec,
+        common::epoch(1),
+        http_controller(port),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("spawn succeeds; the failure is the exit");
     let err = instance.wait_ready().await.expect_err("must fail");
     match err {
         nyanpasu_core_manager::Error::StartupFailed { stderr_tail } => {
@@ -177,9 +197,14 @@ async fn crash_recovers_through_restart_and_reprobe() {
     );
     let spec = common::mihomo_spec(&dir, config);
 
-    let instance = Instance::spawn(spec, 1, http_controller(port), CancellationToken::new())
-        .await
-        .expect("spawn");
+    let instance = Instance::spawn(
+        spec,
+        common::epoch(1),
+        http_controller(port),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("spawn");
     let (recorder, log) = common::record_states(instance.state());
     instance.wait_ready().await.expect("initially healthy");
 
@@ -233,9 +258,14 @@ async fn crash_loop_exhausts_the_budget() {
     spec.options.restart_policy =
         nyanpasu_utils::process::RestartPolicy::OnFailure { max_restarts: 1 };
 
-    let instance = Instance::spawn(spec, 1, http_controller(port), CancellationToken::new())
-        .await
-        .expect("spawn");
+    let instance = Instance::spawn(
+        spec,
+        common::epoch(1),
+        http_controller(port),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("spawn");
     instance
         .wait_ready()
         .await
@@ -265,9 +295,14 @@ async fn user_stop_is_terminal_and_releases_the_port() {
     let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
     let spec = common::mihomo_spec(&dir, config);
 
-    let instance = Instance::spawn(spec, 1, http_controller(port), CancellationToken::new())
-        .await
-        .expect("spawn");
+    let instance = Instance::spawn(
+        spec,
+        common::epoch(1),
+        http_controller(port),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("spawn");
     instance.wait_ready().await.expect("healthy");
     let mut rx = instance.state();
     instance.stop().await.expect("stop");
@@ -311,11 +346,16 @@ async fn custom_readiness_and_success_threshold_gate_running() {
         }
     });
 
-    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
-        .readiness_probe(probe)
-        .spawn()
-        .await
-        .expect("spawn");
+    let instance = Instance::builder(
+        spec,
+        common::epoch(1),
+        http_controller(port),
+        CancellationToken::new(),
+    )
+    .readiness_probe(probe)
+    .spawn()
+    .await
+    .expect("spawn");
     instance.wait_ready().await.expect("threshold reached");
     assert!(calls.load(Ordering::SeqCst) >= 3);
     assert!(matches!(
@@ -347,11 +387,16 @@ async fn liveness_is_off_by_default_after_custom_readiness() {
             async { ProbeResult::Healthy }
         }
     });
-    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
-        .readiness_probe(probe)
-        .spawn()
-        .await
-        .unwrap();
+    let instance = Instance::builder(
+        spec,
+        common::epoch(1),
+        http_controller(port),
+        CancellationToken::new(),
+    )
+    .readiness_probe(probe)
+    .spawn()
+    .await
+    .unwrap();
     instance.wait_ready().await.unwrap();
     let after_ready = calls.load(Ordering::SeqCst);
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -381,12 +426,17 @@ async fn readiness_probe_can_be_reused_for_liveness() {
             async { ProbeResult::Healthy }
         }
     });
-    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
-        .readiness_probe(probe)
-        .liveness_with_readiness_probe()
-        .spawn()
-        .await
-        .unwrap();
+    let instance = Instance::builder(
+        spec,
+        common::epoch(1),
+        http_controller(port),
+        CancellationToken::new(),
+    )
+    .readiness_probe(probe)
+    .liveness_with_readiness_probe()
+    .spawn()
+    .await
+    .unwrap();
     instance.wait_ready().await.unwrap();
     tokio::time::timeout(Duration::from_secs(1), async {
         while !phases.lock().contains(&ProbePhase::Liveness) {
@@ -437,12 +487,17 @@ async fn liveness_hysteresis_is_observe_only_and_recovers() {
             }
         }
     });
-    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
-        .readiness_probe(readiness)
-        .liveness_probe(liveness)
-        .spawn()
-        .await
-        .unwrap();
+    let instance = Instance::builder(
+        spec,
+        common::epoch(1),
+        http_controller(port),
+        CancellationToken::new(),
+    )
+    .readiness_probe(readiness)
+    .liveness_probe(liveness)
+    .spawn()
+    .await
+    .unwrap();
     instance.wait_ready().await.unwrap();
     let pid = instance.pid().unwrap();
 
@@ -503,11 +558,16 @@ async fn absolute_startup_deadline_rejects_late_probe_success() {
         tokio::time::sleep(Duration::from_millis(400)).await;
         ProbeResult::Healthy
     });
-    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
-        .readiness_probe(probe)
-        .spawn()
-        .await
-        .unwrap();
+    let instance = Instance::builder(
+        spec,
+        common::epoch(1),
+        http_controller(port),
+        CancellationToken::new(),
+    )
+    .readiness_probe(probe)
+    .spawn()
+    .await
+    .unwrap();
     let error = instance.wait_ready().await.expect_err("deadline must win");
     assert!(matches!(
         error,
@@ -542,14 +602,19 @@ async fn stop_cancels_a_hanging_liveness_probe() {
             }
         }
     });
-    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
-        .readiness_probe(ProbeHandle::from_fn("ready", |_| async {
-            ProbeResult::Healthy
-        }))
-        .liveness_probe(liveness)
-        .spawn()
-        .await
-        .unwrap();
+    let instance = Instance::builder(
+        spec,
+        common::epoch(1),
+        http_controller(port),
+        CancellationToken::new(),
+    )
+    .readiness_probe(ProbeHandle::from_fn("ready", |_| async {
+        ProbeResult::Healthy
+    }))
+    .liveness_probe(liveness)
+    .spawn()
+    .await
+    .unwrap();
     instance.wait_ready().await.unwrap();
     tokio::time::timeout(Duration::from_secs(1), started.notified())
         .await
@@ -581,15 +646,20 @@ async fn startup_timeout_is_one_budget_across_crash_retries() {
         Duration::from_millis(10),
         Duration::from_millis(10),
     );
-    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
-        .readiness_probe(ProbeHandle::from_fn("never-ready", |_| async {
-            ProbeResult::Unhealthy {
-                detail: Some("not ready".into()),
-            }
-        }))
-        .spawn()
-        .await
-        .unwrap();
+    let instance = Instance::builder(
+        spec,
+        common::epoch(1),
+        http_controller(port),
+        CancellationToken::new(),
+    )
+    .readiness_probe(ProbeHandle::from_fn("never-ready", |_| async {
+        ProbeResult::Unhealthy {
+            detail: Some("not ready".into()),
+        }
+    }))
+    .spawn()
+    .await
+    .unwrap();
     let started = std::time::Instant::now();
     let error = instance.wait_ready().await.expect_err("must time out");
     assert!(matches!(
@@ -649,11 +719,16 @@ async fn exited_run_cancels_its_in_flight_probe_before_replacement() {
             }
         }
     });
-    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
-        .readiness_probe(probe)
-        .spawn()
-        .await
-        .unwrap();
+    let instance = Instance::builder(
+        spec,
+        common::epoch(1),
+        http_controller(port),
+        CancellationToken::new(),
+    )
+    .readiness_probe(probe)
+    .spawn()
+    .await
+    .unwrap();
     let error = instance
         .wait_ready()
         .await

--- a/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
+++ b/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
@@ -41,7 +41,7 @@ async fn manager_builder_forwards_atomic_runtime_health_without_bumping_lifecycl
     let readiness = ProbeHandle::from_fn("manager-readiness", {
         let readiness_calls = readiness_calls.clone();
         move |context| {
-            assert_eq!(context.epoch, 1);
+            assert_eq!(context.epoch, common::epoch(1));
             readiness_calls.fetch_add(1, Ordering::SeqCst);
             async { ProbeResult::Healthy }
         }
@@ -79,7 +79,7 @@ async fn manager_builder_forwards_atomic_runtime_health_without_bumping_lifecycl
     let CoreState::Running { epoch, pid } = running.state else {
         panic!("manager did not publish running")
     };
-    assert_eq!(epoch, 1);
+    assert_eq!(epoch, common::epoch(1));
     assert_eq!(running.health.unwrap().state, HealthState::Healthy);
 
     failing.store(true, Ordering::SeqCst);
@@ -101,9 +101,9 @@ async fn manager_builder_forwards_atomic_runtime_health_without_bumping_lifecycl
     assert!(matches!(
         unhealthy.state,
         CoreState::Running {
-            epoch: 1,
+            epoch,
             pid: current
-        } if current == pid
+        } if epoch == common::epoch(1) && current == pid
     ));
     assert_eq!(unhealthy.changed_at, running_changed_at);
     manager.stop().await.unwrap();
@@ -194,7 +194,7 @@ async fn start_publishes_running_and_rejects_double_start() {
     let CoreState::Running { epoch, pid } = state else {
         unreachable!()
     };
-    assert!(epoch >= 1 && pid > 0);
+    assert!(epoch >= common::epoch(1) && pid > 0);
     let status = manager.status();
     assert_eq!(
         status.spec.as_ref().map(|s| s.config_path.clone()),
@@ -639,7 +639,7 @@ async fn manager_sweeps_stale_artifacts_and_advances_epoch() {
         .expect("start after sweep");
     assert!(matches!(
         manager.status().state,
-        CoreState::Running { epoch: 10, .. }
+        CoreState::Running { epoch, .. } if epoch == common::epoch(10)
     ));
     manager.shutdown().await.expect("shutdown");
 }
@@ -736,7 +736,7 @@ async fn initial_start_stop_uncertainty_quarantines_until_recovery() {
         .expect_err("quarantine must reject another initial start");
     assert!(matches!(
         start_error,
-        Error::ManagerQuarantined { epoch: 1, .. }
+        Error::ManagerQuarantined { epoch, .. } if epoch == common::epoch(1)
     ));
 
     std::fs::write(&pid_path, record).unwrap();

--- a/crates/nyanpasu-core-manager/tests/orphan_recovery.rs
+++ b/crates/nyanpasu-core-manager/tests/orphan_recovery.rs
@@ -144,8 +144,48 @@ async fn hard_killed_manager_is_reaped_and_all_epoch_artifacts_are_swept() {
         panic!("recovery core is not running")
     };
     assert!(
-        epoch > swept_epoch,
+        epoch.get() > swept_epoch,
         "epoch {epoch} must exceed {swept_epoch}"
     );
     manager.shutdown().await.expect("shutdown recovery core");
+}
+
+/// A runtime directory can carry `config-0.yaml` from an interrupted write, and
+/// zero is not a number the allocator can ever issue. Discovery therefore reads
+/// artifact numbers back from filenames as plain integers rather than as
+/// epochs — and must still clean them, because a zero nothing is willing to
+/// name is a zero that leaks forever.
+#[tokio::test]
+async fn zero_named_artifacts_are_swept_without_becoming_an_epoch() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let runtime_dir = dir.join("runtime");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    for name in [
+        "config-0.yaml",
+        "config-0.yaml.backup-3",
+        "core-0.pid.tmp-1",
+        "config-4.yaml",
+    ] {
+        std::fs::write(runtime_dir.join(name), b"stale\n").unwrap();
+    }
+
+    let manager = CoreManager::new(ManagerOptions {
+        runtime_dir: Some(runtime_dir.clone()),
+        ..ManagerOptions::default()
+    })
+    .await
+    .expect("construct a manager over a zero-named artifact");
+
+    let mut entries = tokio::fs::read_dir(&runtime_dir).await.unwrap();
+    let mut leftovers = Vec::new();
+    while let Some(entry) = entries.next_entry().await.unwrap() {
+        leftovers.push(entry.file_name().to_string_lossy().into_owned());
+    }
+    leftovers.sort();
+    assert_eq!(leftovers, [".manager.lock", "logs"], "unswept artifacts");
+
+    // The seed a zero artifact contributes is still zero, so the first epoch
+    // the domain sees is one — proven against the allocator directly by
+    // `epochs_are_monotone_past_the_seed_and_never_zero`.
+    assert!(matches!(manager.status().state, CoreState::Stopped { .. }));
 }

--- a/crates/nyanpasu-core-manager/tests/real_cores.rs
+++ b/crates/nyanpasu-core-manager/tests/real_cores.rs
@@ -198,7 +198,7 @@ async fn config_update(core: RealCore) {
 
     // CAS: a stale expected revision is rejected.
     let bogus = RevisionId {
-        epoch: u64::MAX,
+        epoch: common::epoch(u64::MAX),
         generation: u64::MAX,
         effective_hash: "bogus".into(),
     };

--- a/crates/nyanpasu-core-manager/tests/real_mihomo_smoke.rs
+++ b/crates/nyanpasu-core-manager/tests/real_mihomo_smoke.rs
@@ -75,7 +75,7 @@ async fn real_core_starts_probes_and_stops() {
         host: clash_api::Host::http(format!("127.0.0.1:{ctrl_port}")).unwrap(),
         secret: None,
     };
-    let instance = Instance::spawn(spec, 1, controller, CancellationToken::new())
+    let instance = Instance::spawn(spec, common::epoch(1), controller, CancellationToken::new())
         .await
         .expect("spawn");
     instance

--- a/crates/nyanpasu-core-manager/tests/reconcile.rs
+++ b/crates/nyanpasu-core-manager/tests/reconcile.rs
@@ -53,7 +53,7 @@ async fn reconcile_with_a_stale_expectation_changes_nothing() {
     let running = manager.status();
 
     let stale = RevisionId {
-        epoch: 99,
+        epoch: common::epoch(99),
         generation: 9,
         effective_hash: "deadbeefdeadbeef".to_owned(),
     };
@@ -85,7 +85,7 @@ async fn reconcile_against_a_stopped_manager_rejects_a_believed_revision() {
     let spec = common::mihomo_spec(&dir, config);
 
     let expected = RevisionId {
-        epoch: 1,
+        epoch: common::epoch(1),
         generation: 1,
         effective_hash: "0123456789abcdef".to_owned(),
     };

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -8,10 +8,10 @@ use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_core_manager::{
     ApplyOutcome, ConfigInput, ConfigRevision, ControlOptions, CoreCommand, CoreCommandEnvelope,
     CoreControl, CoreError as ControlError, CoreErrorKind, CoreKind, CoreManager as Manager,
-    CoreSpec, CoreState as ManagerCoreState, CoreStatus, Error as ManagerError, ExecutorExit,
-    HealthState, HealthStatus, Host, InstanceOptions, InstanceSpec, LocalIpcPolicy, LogFrame,
-    LogLevel, ManagerOptions, OperationHandle, OperationId, OperationOutput, OperationState,
-    ReconcileRequest, RevisionId,
+    CoreSpec, CoreState as ManagerCoreState, CoreStatus, Epoch, Error as ManagerError,
+    ExecutorExit, HealthState, HealthStatus, Host, InstanceOptions, InstanceSpec, LocalIpcPolicy,
+    LogFrame, LogLevel, ManagerOptions, OperationHandle, OperationId, OperationOutput,
+    OperationState, ReconcileRequest, RevisionId,
 };
 use nyanpasu_ipc::api::{
     R, RBuilder,
@@ -403,7 +403,7 @@ impl CoreManagerService {
                         expected_digest: expected_digest.as_ref().map(|digest| digest.to_string()),
                     },
                     options: spec.options,
-                    expected_applied: expected_applied.as_ref().map(map_revision_id),
+                    expected_applied: expected_applied.as_ref().map(map_revision_id).transpose()?,
                 }))
             }
             CoreCommandInfo::Stop => CoreCommand::Stop,
@@ -711,20 +711,25 @@ fn map_health(health: &HealthStatus) -> CoreHealthInfo {
 /// 0o700 runtime directory, which the client cannot read.
 fn map_revision(revision: &ConfigRevision) -> ConfigRevisionInfo {
     ConfigRevisionInfo {
-        epoch: revision.epoch,
+        epoch: revision.epoch.get(),
         generation: revision.generation,
         source_hash: revision.source_hash.clone(),
         effective_hash: revision.effective_hash.clone(),
     }
 }
 
-/// The wire CAS token, as the manager compares it.
-fn map_revision_id(info: &RevisionIdInfo) -> RevisionId {
-    RevisionId {
-        epoch: info.epoch,
+/// The wire CAS token, as the manager compares it. The epoch arrives from a
+/// client, so it is validated rather than trusted: zero names no epoch the
+/// allocator can ever have issued, and a token that cannot match is a
+/// malformed request, not a mismatch.
+fn map_revision_id(info: &RevisionIdInfo) -> Result<RevisionId, OpError> {
+    let epoch = Epoch::try_from(info.epoch)
+        .map_err(|_| OpError::plain("expected revision epoch must be nonzero"))?;
+    Ok(RevisionId {
+        epoch,
         generation: info.generation,
         effective_hash: info.effective_hash.clone(),
-    }
+    })
 }
 
 /// Project an apply result onto the wire.
@@ -836,20 +841,24 @@ fn map_state_detail(state: &ManagerCoreState) -> Option<CoreStateDetail> {
         ManagerCoreState::Stopped { reason } => Some(CoreStateDetail::Stopped {
             reason: reason.as_ref().map(ToString::to_string),
         }),
-        ManagerCoreState::Starting { epoch } => Some(CoreStateDetail::Starting { epoch: *epoch }),
+        ManagerCoreState::Starting { epoch } => {
+            Some(CoreStateDetail::Starting { epoch: epoch.get() })
+        }
         ManagerCoreState::Running { epoch, pid } => Some(CoreStateDetail::Running {
-            epoch: *epoch,
+            epoch: epoch.get(),
             pid: *pid,
         }),
         ManagerCoreState::Restarting { epoch, attempt } => Some(CoreStateDetail::Restarting {
-            epoch: *epoch,
+            epoch: epoch.get(),
             attempt: *attempt,
         }),
         ManagerCoreState::Switching { from, to } => Some(CoreStateDetail::Switching {
-            from: *from,
-            to: *to,
+            from: from.map(Epoch::get),
+            to: to.get(),
         }),
-        ManagerCoreState::Stopping { epoch } => Some(CoreStateDetail::Stopping { epoch: *epoch }),
+        ManagerCoreState::Stopping { epoch } => {
+            Some(CoreStateDetail::Stopping { epoch: epoch.get() })
+        }
         // `CoreState` is `#[non_exhaustive]`; an unknown state has no faithful
         // projection, so it is reported as absent.
         _ => None,
@@ -965,6 +974,12 @@ async fn canonical_config_path(config_file: &Path) -> Result<Utf8PathBuf, OpErro
 
 #[cfg(test)]
 mod tests {
+    /// The epoch a test means when it writes a number. Production code keeps
+    /// paying the nonzero check at every boundary; a test that skipped it
+    /// would stop exercising the barrier it is meant to prove.
+    fn epoch(value: u64) -> Epoch {
+        Epoch::new(value).expect("a test epoch must be nonzero")
+    }
     use std::time::Duration;
 
     use nyanpasu_core_manager::StopReason;
@@ -1008,14 +1023,17 @@ mod tests {
         assert_eq!(
             format!(
                 "{:?}",
-                map_core_state(&ManagerCoreState::Starting { epoch: 1 })
+                map_core_state(&ManagerCoreState::Starting { epoch: epoch(1) })
             ),
             "Stopped(None)"
         );
         assert_eq!(
             format!(
                 "{:?}",
-                map_core_state(&ManagerCoreState::Running { epoch: 1, pid: 42 })
+                map_core_state(&ManagerCoreState::Running {
+                    epoch: epoch(1),
+                    pid: 42
+                })
             ),
             "Running"
         );
@@ -1023,7 +1041,7 @@ mod tests {
             format!(
                 "{:?}",
                 map_core_state(&ManagerCoreState::Restarting {
-                    epoch: 1,
+                    epoch: epoch(1),
                     attempt: 2,
                 })
             ),
@@ -1033,8 +1051,8 @@ mod tests {
             format!(
                 "{:?}",
                 map_core_state(&ManagerCoreState::Switching {
-                    from: Some(1),
-                    to: 2,
+                    from: Some(epoch(1)),
+                    to: epoch(2),
                 })
             ),
             "Running"
@@ -1042,7 +1060,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{:?}",
-                map_core_state(&ManagerCoreState::Stopping { epoch: 2 })
+                map_core_state(&ManagerCoreState::Stopping { epoch: epoch(2) })
             ),
             "Running"
         );
@@ -1094,14 +1112,20 @@ mod tests {
     #[test]
     fn the_state_bridge_forwards_only_real_transitions() {
         let states = [
-            ManagerCoreState::Starting { epoch: 1 },
-            ManagerCoreState::Running { epoch: 1, pid: 42 },
-            ManagerCoreState::Switching {
-                from: Some(1),
-                to: 2,
+            ManagerCoreState::Starting { epoch: epoch(1) },
+            ManagerCoreState::Running {
+                epoch: epoch(1),
+                pid: 42,
             },
-            ManagerCoreState::Stopping { epoch: 2 },
-            ManagerCoreState::Running { epoch: 2, pid: 43 },
+            ManagerCoreState::Switching {
+                from: Some(epoch(1)),
+                to: epoch(2),
+            },
+            ManagerCoreState::Stopping { epoch: epoch(2) },
+            ManagerCoreState::Running {
+                epoch: epoch(2),
+                pid: 43,
+            },
             ManagerCoreState::Stopped {
                 reason: Some(StopReason::User),
             },
@@ -1123,11 +1147,14 @@ mod tests {
     #[test]
     fn terminal_stop_is_not_resurrected_by_shutdown() {
         let states = [
-            ManagerCoreState::Running { epoch: 1, pid: 42 },
+            ManagerCoreState::Running {
+                epoch: epoch(1),
+                pid: 42,
+            },
             ManagerCoreState::Stopped {
                 reason: Some(StopReason::Error("boom".to_owned())),
             },
-            ManagerCoreState::Stopping { epoch: 1 },
+            ManagerCoreState::Stopping { epoch: epoch(1) },
             ManagerCoreState::Stopped {
                 reason: Some(StopReason::User),
             },
@@ -1159,16 +1186,19 @@ mod tests {
                 },
             ),
             (
-                ManagerCoreState::Starting { epoch: 1 },
+                ManagerCoreState::Starting { epoch: epoch(1) },
                 CoreStateDetail::Starting { epoch: 1 },
             ),
             (
-                ManagerCoreState::Running { epoch: 1, pid: 42 },
+                ManagerCoreState::Running {
+                    epoch: epoch(1),
+                    pid: 42,
+                },
                 CoreStateDetail::Running { epoch: 1, pid: 42 },
             ),
             (
                 ManagerCoreState::Restarting {
-                    epoch: 1,
+                    epoch: epoch(1),
                     attempt: 2,
                 },
                 CoreStateDetail::Restarting {
@@ -1178,8 +1208,8 @@ mod tests {
             ),
             (
                 ManagerCoreState::Switching {
-                    from: Some(1),
-                    to: 2,
+                    from: Some(epoch(1)),
+                    to: epoch(2),
                 },
                 CoreStateDetail::Switching {
                     from: Some(1),
@@ -1187,7 +1217,7 @@ mod tests {
                 },
             ),
             (
-                ManagerCoreState::Stopping { epoch: 2 },
+                ManagerCoreState::Stopping { epoch: epoch(2) },
                 CoreStateDetail::Stopping { epoch: 2 },
             ),
         ];
@@ -1202,7 +1232,7 @@ mod tests {
     #[test]
     fn the_detail_field_recovers_what_the_wire_state_flattens() {
         let restarting = ManagerCoreState::Restarting {
-            epoch: 1,
+            epoch: epoch(1),
             attempt: 3,
         };
         assert!(matches!(
@@ -1261,7 +1291,7 @@ mod tests {
     #[test]
     fn the_revision_projection_drops_the_runtime_path() {
         let revision = ConfigRevision {
-            epoch: 3,
+            epoch: epoch(3),
             generation: 7,
             source_hash: "0123456789abcdef".to_owned(),
             effective_hash: "fedcba9876543210".to_owned(),
@@ -1300,7 +1330,7 @@ mod tests {
 
     fn revision(generation: u64) -> ConfigRevision {
         ConfigRevision {
-            epoch: 3,
+            epoch: epoch(3),
             generation,
             source_hash: "0123456789abcdef".to_owned(),
             effective_hash: "fedcba9876543210".to_owned(),
@@ -1422,13 +1452,34 @@ mod tests {
                 epoch: 3,
                 generation: 7,
                 effective_hash: "fedcba9876543210".to_owned(),
-            }),
+            })
+            .unwrap_or_else(|_| panic!("a nonzero wire epoch is a revision id")),
             RevisionId {
-                epoch: 3,
+                epoch: epoch(3),
                 generation: 7,
                 effective_hash: "fedcba9876543210".to_owned(),
             }
         );
+    }
+
+    /// Zero names no epoch the allocator can ever have issued, so a CAS token
+    /// carrying it is malformed rather than merely stale — and a client that
+    /// sends one gets told which field is wrong instead of a mismatch.
+    #[test]
+    fn a_zero_expected_epoch_is_rejected_rather_than_compared() {
+        let error = map_revision_id(&RevisionIdInfo {
+            epoch: 0,
+            generation: 7,
+            effective_hash: "fedcba9876543210".to_owned(),
+        })
+        .expect_err("zero is not an epoch");
+
+        assert_eq!(error.message, "expected revision epoch must be nonzero");
+        // Rejected while promoting wire data, so it never reaches the operation
+        // registry: no kind, no retry advice, and the operation id stays free
+        // for a corrected resubmission.
+        assert_eq!(error.kind, None);
+        assert_eq!(error.retryable, None);
     }
 
     fn status_of(state: ManagerCoreState) -> CoreStatus {
@@ -1504,7 +1555,10 @@ mod tests {
 
         // A manager transition with no echo yet: the snapshot leads, the legacy
         // state follows.
-        states.send_replace(status_of(ManagerCoreState::Running { epoch: 1, pid: 7 }));
+        states.send_replace(status_of(ManagerCoreState::Running {
+            epoch: epoch(1),
+            pid: 7,
+        }));
         let status = tokio::time::timeout(Duration::from_secs(5), events.recv())
             .await
             .expect("timed out waiting for the manager status snapshot")
@@ -1547,7 +1601,10 @@ mod tests {
     /// adapter republishes the unchanged value, which `send_modify` notifies on.
     #[tokio::test]
     async fn republishing_an_unchanged_echo_still_refreshes_the_snapshot() {
-        let states = watch::Sender::new(status_of(ManagerCoreState::Running { epoch: 1, pid: 7 }));
+        let states = watch::Sender::new(status_of(ManagerCoreState::Running {
+            epoch: epoch(1),
+            pid: 7,
+        }));
         let requested = watch::Sender::new(Some(mihomo()));
         let hub = EventHub::new();
         let mut events = hub.subscribe();
@@ -1705,14 +1762,20 @@ mod tests {
     #[test]
     fn the_snapshot_stream_carries_every_transition_the_legacy_stream_suppresses() {
         let states = [
-            ManagerCoreState::Starting { epoch: 1 },
-            ManagerCoreState::Running { epoch: 1, pid: 42 },
+            ManagerCoreState::Starting { epoch: epoch(1) },
+            ManagerCoreState::Running {
+                epoch: epoch(1),
+                pid: 42,
+            },
             ManagerCoreState::Restarting {
-                epoch: 1,
+                epoch: epoch(1),
                 attempt: 2,
             },
-            ManagerCoreState::Running { epoch: 1, pid: 43 },
-            ManagerCoreState::Stopping { epoch: 1 },
+            ManagerCoreState::Running {
+                epoch: epoch(1),
+                pid: 43,
+            },
+            ManagerCoreState::Stopping { epoch: epoch(1) },
             ManagerCoreState::Stopped {
                 reason: Some(StopReason::User),
             },
@@ -1759,7 +1822,7 @@ mod tests {
     fn the_snapshot_payload_keeps_the_lossy_state_and_adds_the_faithful_detail() {
         let infos = project_core_infos(
             &status_of(ManagerCoreState::Restarting {
-                epoch: 3,
+                epoch: epoch(3),
                 attempt: 2,
             }),
             Some(CoreType::Clash(ClashCoreType::MihomoAlpha)),

--- a/docs/superpowers/specs/2026-07-18-nyanpasu-core-manager-design.md
+++ b/docs/superpowers/specs/2026-07-18-nyanpasu-core-manager-design.md
@@ -172,11 +172,11 @@ pub struct CoreStatus {              // watch 载荷,manager 对外快照
 #[non_exhaustive]
 pub enum CoreState {
     Stopped { reason: Option<StopReason> },   // 初始值 reason=None
-    Starting   { epoch: u64 },
-    Running    { epoch: u64, pid: u32 },
-    Restarting { epoch: u64, attempt: u32 },
-    Switching  { from: Option<u64>, to: u64 }, // 切换窗口(平滑/硬共用)
-    Stopping   { epoch: u64 },
+    Starting   { epoch: Epoch },
+    Running    { epoch: Epoch, pid: u32 },
+    Restarting { epoch: Epoch, attempt: u32 },
+    Switching  { from: Option<Epoch>, to: Epoch }, // 切换窗口(平滑/硬共用)
+    Stopping   { epoch: Epoch },
 }
 ```
 
@@ -225,10 +225,10 @@ pub enum Error {
 
 ```rust
 impl Instance {
-    pub async fn spawn(spec: InstanceSpec, epoch: u64, controller: ResolvedController,
+    pub async fn spawn(spec: InstanceSpec, epoch: Epoch, controller: ResolvedController,
                        token: CancellationToken) -> Result<Instance, Error>;
     pub fn state(&self) -> watch::Receiver<InstanceState>;
-    pub fn epoch(&self) -> u64;
+    pub fn epoch(&self) -> Epoch;
     pub fn spec(&self) -> &InstanceSpec;
     pub async fn wait_ready(&self) -> Result<(), Error>;   // 等到 Running 或 Stopped
     pub async fn stop(self) -> Result<(), Error>;
@@ -259,7 +259,7 @@ impl CoreManager {
 ```
 
 - 控制面方法由一把 async Mutex 串行化;`switch` 进行中到达的控制命令排队等待。
-- **epoch**:控制锁内的单调分配器(`EpochAllocator`),由控制面 Mutex 串行化,0 保留表示"无"。进程内单调即满足路径唯一性(named pipe 随 server 关闭消失;unix socket 残留文件由启动清扫处理)。
+- **epoch**:控制锁内的单调分配器(`EpochAllocator`)发放 `Epoch(NonZeroU64)`,由控制面 Mutex 串行化;"无"由 `Option<Epoch>` 表达而非 0 哨兵。类型止步于本 crate——文件名、pid 记录、`LogFrame`、DNS 记录与 IPC 仍是裸 `u64`,产物发现读回的数字亦然。进程内单调即满足路径唯一性(named pipe 随 server 关闭消失;unix socket 残留文件由启动清扫处理)。
 - 状态聚合:manager 的转发 task 订阅当前 Instance 的 `watch<InstanceState>`,映射为 `CoreState`(补 epoch)写入对外 watch;切换流程期间由流程直接发布 `Switching`。
 - `stop` 后 manager 保留 last spec(旧实现同语义:stop 后可 restart)。
 


### PR DESCRIPTION
> Follows #395, which is now merged. Base is `main` and the diff is the single commit this PR adds.

## Why

`epoch` and `generation` are both monotone `u64` counters and they sit adjacent in the same types and the same parameter lists, so nothing stops one being passed where the other belongs:

```rust
pub struct ConfigRevision { pub epoch: u64, pub generation: u64, .. }
pub struct RevisionId     { pub epoch: u64, pub generation: u64, .. }
pub async fn backup(&self, epoch: u64, generation: u64) -> ..
```

The one production `backup` caller draws its two arguments from two *different* plans:

```rust
.backup(
    current.plan.revision.epoch,        // from current
    prepared.plan.revision.generation,  // from prepared
)
```

Both the field and the plan can be swapped silently. No such swap exists in this repo's history, and a wrong epoch usually selects a nonexistent `config-{epoch}.yaml` and fails target validation rather than corrupting anything — but this is the configuration backup/rollback path, where a rare silent mix-up is disproportionately expensive.

`Epoch(NonZeroU64)` gives the pair a compiler-checked difference. The allocator already used `checked_add(1)` and promised never to return zero, and "no epoch" was already spelled `Option`, so the nonzero invariant only states what the implementation already guaranteed — and rules out a zero arriving from anywhere else.

## The rule that explains every exception

```
inside the domain (a live epoch the allocator issued)   ->  Epoch
at an encoded boundary (filename, pid record, LogFrame,
                        DNS record, IPC wire)           ->  u64
from an untrusted source (a number read back off disk)  ->  u64, never promoted
```

A number encoded into a filename is not an epoch; it is a number that once named one. So artifact discovery keeps reading `config-{n}.yaml` back as a plain integer, and a `config-0.yaml` left by an interrupted write is still swept — a zero nothing is willing to name is a zero that leaks forever. `RuntimeConfigStore`'s public surface is typed and delegates to two crate-private raw helpers that only the orphan sweep reaches.

There are exactly five conversions out of the domain: the `EpochPidFile` submodule API, the `LogParser` wire field, the persisted DNS record (twice), and the service bridge.

## What is *not* touched

`nyanpasu-utils`, `nyanpasu-core-metadata`, `nyanpasu_ipc`, `Cargo.lock` — zero lines. `LogFrame.epoch`, `EpochPidRecord.epoch`, `DnsOverrideRecord.runtime_epoch` and every IPC field stay `u64`, so no persisted file, no JSONL archive, no wire message and no generated TypeScript binding changes. `Epoch` deliberately derives no serde: a transparent newtype would preserve the JSON token but not compatibility, because `NonZeroU64`'s `Deserialize` would immediately reject an existing record containing zero.

## The one behaviour change

`map_revision_id` was infallible. A CAS token carrying `epoch: 0` used to build a `RevisionId` that could never match, so the reconcile was refused as a mismatch and changed nothing. It is now rejected at the bridge as a malformed request.

The operation is refused and the manager is untouched either way, but the surfaces differ: before, the request was admitted, registered, queued, and failed with `revision_conflict`; now it is rejected before `CoreControl::submit`, so no operation is registered, the error carries no kind and no retry advice, and the operation id stays free for a corrected resubmission. No client sends `epoch: 0` deliberately — absence is spelled `expected_applied: None`, and the app takes its token straight from the current status snapshot.

Validating here is the right layer: `RevisionId` now contains an `Epoch`, so an invalid wire integer has to be rejected while wire data is promoted into the domain rather than after.

## Deliberately not simplified

- **`Epoch` gets no `From<u64>`, no `From<Epoch> for u64`, no `PartialEq<u64>` and no arithmetic.** `From<u64>` would let any untrusted integer enter the domain without acknowledging zero; `.into()` would hide the exact boundary this change exists to make visible; `PartialEq<u64>` would make the tests easier by weakening the barrier they are meant to prove. `Display` is kept, so filenames and diagnostics still read `format!("config-{epoch}.yaml")` instead of spreading `.get()` through internal code.
- **The template probe still renders zero.** Manager construction validates the controller template before any epoch exists. A template may put `{epoch}` in a parent component, and the rendered parent is canonicalized and checked for containment — so `runtime/0/` and `runtime/1/` need not both exist, nor resolve through the same symlink. Which number renders is observable, and it stays the one it has always been.
- **`LogParser` keeps a bare `u64`.** It holds the field that will be written into a `LogFrame`, and `summarize_output` deliberately passes zero for output that belongs to no epoch.

## Breaking public API

`CoreState::{Starting,Running,Restarting,Switching,Stopping}`, `ConfigRevision.epoch`, `RevisionId.epoch`, `RuntimeLaunchRequest.epoch`, `RuntimeInstance::epoch()`, `Instance::{builder,spawn,epoch}`, `ProbeContext.epoch`, `DnsController::apply`, `Error::ManagerQuarantined.epoch`, and nine `RuntimeConfigStore` methods.

The app companion is ~10 lines in two files (`actor_v2/endpoint.rs`, `actor_v2/facade.rs`) plus test literals, and lands as its own PR after the app's own in-flight branch merges. The `nyanpasu-utils` gitlink needs no advance.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace --no-fail-fast` are clean: **484 passed / 0 failed / 24 ignored**.

Two known flakes surfaced and were each cleared by an isolated rerun: the recorded `compensation_publishes_restart_before_replacement_is_ready` race, and `dropping_live_manager_releases_runtime_ownership`, whose error whitelist accepts `RuntimeDirectoryOwned` and `PermissionDenied` but not the `NotFound` a delete-pending file can return on Windows. The second is a pre-existing test defect, unrelated to this change and left alone.

New guards: zero-named artifacts are swept without becoming an epoch; the persisted DNS record still carries a bare JSON number; a zero CAS epoch is rejected with no kind and no retry advice. The existing launch-request echo guards now compare typed epochs, which additionally proves the echoed value cannot be a generation.

Because `#[cfg(unix)]` and `#[cfg(target_os = "macos")]` code never compiles on the authoring host, this was also checked with `cargo check --target x86_64-unknown-linux-gnu` (clean). macOS cannot be cross-checked from Windows — `aws-lc-sys` needs the SDK — so the `#[cfg(target_os = "macos")]` DNS module was verified by inspection (two epoch sites) and rests on CI.

https://claude.ai/code/session_01BsiU6nsZN2i4fcNntm2xZd
