### PR TITLE
refactor(core-manager)!: name the transposable inputs across classify, probes, health and launch paths

### DIFF
--- a/crates/nyanpasu-core-manager/README.md
+++ b/crates/nyanpasu-core-manager/README.md
@@ -262,16 +262,19 @@ authoritative and never probes the binary.
 ```rust
 use std::{num::NonZeroU32, time::Duration};
 use nyanpasu_core_manager::{
-    CoreManager, HealthPolicy, ProbeHandle, ProbeResult,
+    CoreManager, HealthPolicy, HealthPolicySpec, HealthThresholds, ProbeHandle,
+    ProbeResult,
 };
 
-spec.options.health = HealthPolicy::new(
-    Duration::from_millis(250),
-    Duration::from_secs(1),
-    NonZeroU32::new(3).unwrap(), // failures before Unhealthy
-    NonZeroU32::new(2).unwrap(), // successes before Healthy/ready
-    Duration::from_secs(2),      // initial failure grace per process run
-)?;
+spec.options.health = HealthPolicy::new(HealthPolicySpec {
+    interval: Duration::from_millis(250),
+    timeout: Duration::from_secs(1),
+    thresholds: HealthThresholds {
+        failure: NonZeroU32::new(3).unwrap(), // failures before Unhealthy
+        success: NonZeroU32::new(2).unwrap(), // successes before Healthy/ready
+    },
+    start_period: Duration::from_secs(2),     // initial failure grace per process run
+})?;
 
 let tcp_liveness = ProbeHandle::from_fn("proxy-tcp", |context| async move {
     match tokio::net::TcpStream::connect(("127.0.0.1", 7890)).await {
@@ -492,19 +495,23 @@ nyanpasu_core_manager::kind::check_config(spec).await?;
 ```rust
 use std::time::Duration;
 use std::num::NonZeroU32;
-use nyanpasu_core_manager::{HealthPolicy, InstanceOptions};
+use nyanpasu_core_manager::{
+    HealthPolicy, HealthPolicySpec, HealthThresholds, InstanceOptions,
+};
 use nyanpasu_utils::process::{Backoff, RestartPolicy};
 
 let options = InstanceOptions {
     // Total budget for the initial start, crash retries included.
     startup_timeout: Duration::from_secs(30),
-    health: HealthPolicy::new(
-        Duration::from_millis(250), // delay after each completed probe
-        Duration::from_secs(1),     // per-attempt timeout
-        NonZeroU32::new(3).unwrap(),// failures before Unhealthy
-        NonZeroU32::MIN,            // successes before Healthy/ready
-        Duration::ZERO,             // failure grace per child run
-    )?,
+    health: HealthPolicy::new(HealthPolicySpec {
+        interval: Duration::from_millis(250), // delay after each completed probe
+        timeout: Duration::from_secs(1),      // per-attempt timeout
+        thresholds: HealthThresholds {
+            failure: NonZeroU32::new(3).unwrap(), // failures before Unhealthy
+            success: NonZeroU32::MIN,             // successes before Healthy/ready
+        },
+        start_period: Duration::ZERO,         // failure grace per child run
+    })?,
     restart_policy: RestartPolicy::OnFailure { max_restarts: 5 },
     backoff: Backoff::exponential(Duration::from_secs(1), Duration::from_secs(30))
         .with_jitter(),

--- a/crates/nyanpasu-core-manager/src/config/mihomo.rs
+++ b/crates/nyanpasu-core-manager/src/config/mihomo.rs
@@ -203,27 +203,34 @@ pub(crate) enum OverlapBlock {
     InboundSurface,
 }
 
+/// One side of a classification: the two documents an epoch was planned from
+/// and the process spec it would run under. Bundling them keeps each side
+/// together instead of interleaving six references in which the four
+/// `&Mapping` are mutually interchangeable and so are the two `&InstanceSpec`.
+#[derive(Clone, Copy)]
+pub(crate) struct ConfigClassificationView<'a> {
+    pub source: &'a Mapping,
+    pub effective: &'a Mapping,
+    pub spec: &'a InstanceSpec,
+}
+
 pub(crate) fn classify(
-    current_source: &Mapping,
-    current_effective: &Mapping,
-    current_spec: &InstanceSpec,
-    desired_source: &Mapping,
-    desired_effective: &Mapping,
-    desired_spec: &InstanceSpec,
+    current: ConfigClassificationView<'_>,
+    desired: ConfigClassificationView<'_>,
 ) -> Result<ConfigChange, Error> {
-    if process_spec_changed(current_spec, desired_spec) {
+    if process_spec_changed(current.spec, desired.spec) {
         return Ok(ConfigChange::Switch);
     }
 
-    let source_diff = diff(current_source, desired_source);
-    if desired_spec.core.kind != CoreKind::Mihomo {
+    let source_diff = diff(current.source, desired.source);
+    if desired.spec.core.kind != CoreKind::Mihomo {
         // Non-mihomo kinds degrade to Switch. An identical config is still a
         // Noop — but only when the *effective* documents also match: a
         // capability change (e.g. the binary was replaced in place and now
         // resolves a different version) can alter the derived config and the
         // resolved controller without any source edit, and that must restart.
         let unchanged =
-            source_diff.is_empty() && diff(current_effective, desired_effective).is_empty();
+            source_diff.is_empty() && diff(current.effective, desired.effective).is_empty();
         return Ok(if unchanged {
             ConfigChange::Noop
         } else {
@@ -240,7 +247,7 @@ pub(crate) fn classify(
     }) {
         return Ok(ConfigChange::Switch);
     }
-    classify_documents(current_effective, desired_effective)
+    classify_documents(current.effective, desired.effective)
 }
 
 fn process_spec_changed(current: &InstanceSpec, desired: &InstanceSpec) -> bool {
@@ -542,12 +549,16 @@ mod tests {
             assert!(
                 matches!(
                     classify(
-                        &mapping("mixed-port: 7890"),
-                        &Mapping::new(),
-                        &spec,
-                        &mapping("mixed-port: 7890"),
-                        &Mapping::new(),
-                        &spec,
+                        ConfigClassificationView {
+                            source: &mapping("mixed-port: 7890"),
+                            effective: &Mapping::new(),
+                            spec: &spec,
+                        },
+                        ConfigClassificationView {
+                            source: &mapping("mixed-port: 7890"),
+                            effective: &Mapping::new(),
+                            spec: &spec,
+                        },
                     )
                     .unwrap(),
                     ConfigChange::Noop
@@ -564,12 +575,16 @@ mod tests {
         let spec = spec(CoreKind::ClashRust, "clash-rs");
         assert!(matches!(
             classify(
-                &mapping("mixed-port: 7890"),
-                &mapping("external-controller: 127.0.0.1:9090"),
-                &spec,
-                &mapping("mixed-port: 7890"),
-                &mapping("external-controller-pipe: /tmp/core-1.sock"),
-                &spec,
+                ConfigClassificationView {
+                    source: &mapping("mixed-port: 7890"),
+                    effective: &mapping("external-controller: 127.0.0.1:9090"),
+                    spec: &spec,
+                },
+                ConfigClassificationView {
+                    source: &mapping("mixed-port: 7890"),
+                    effective: &mapping("external-controller-pipe: /tmp/core-1.sock"),
+                    spec: &spec,
+                },
             )
             .unwrap(),
             ConfigChange::Switch
@@ -584,12 +599,16 @@ mod tests {
         let spec = spec(CoreKind::Mihomo, "mihomo");
         assert!(matches!(
             classify(
-                &mapping("mixed-port: 7890"),
-                &mapping("external-controller: 127.0.0.1:9090"),
-                &spec,
-                &mapping("mixed-port: 7890"),
-                &mapping("external-controller-pipe: /tmp/core-1.sock"),
-                &spec,
+                ConfigClassificationView {
+                    source: &mapping("mixed-port: 7890"),
+                    effective: &mapping("external-controller: 127.0.0.1:9090"),
+                    spec: &spec,
+                },
+                ConfigClassificationView {
+                    source: &mapping("mixed-port: 7890"),
+                    effective: &mapping("external-controller-pipe: /tmp/core-1.sock"),
+                    spec: &spec,
+                },
             )
             .unwrap(),
             ConfigChange::Switch
@@ -603,36 +622,48 @@ mod tests {
         changed_binary.core.binary_path = "other-mihomo".into();
         assert!(matches!(
             classify(
-                &mapping("external-controller: 127.0.0.1:9090"),
-                &Mapping::new(),
-                &current,
-                &mapping("external-controller: 127.0.0.1:9091"),
-                &Mapping::new(),
-                &current,
+                ConfigClassificationView {
+                    source: &mapping("external-controller: 127.0.0.1:9090"),
+                    effective: &Mapping::new(),
+                    spec: &current,
+                },
+                ConfigClassificationView {
+                    source: &mapping("external-controller: 127.0.0.1:9091"),
+                    effective: &Mapping::new(),
+                    spec: &current,
+                },
             )
             .unwrap(),
             ConfigChange::Switch
         ));
         assert!(matches!(
             classify(
-                &Mapping::new(),
-                &Mapping::new(),
-                &current,
-                &Mapping::new(),
-                &Mapping::new(),
-                &changed_binary,
+                ConfigClassificationView {
+                    source: &Mapping::new(),
+                    effective: &Mapping::new(),
+                    spec: &current,
+                },
+                ConfigClassificationView {
+                    source: &Mapping::new(),
+                    effective: &Mapping::new(),
+                    spec: &changed_binary,
+                },
             )
             .unwrap(),
             ConfigChange::Switch
         ));
         assert!(matches!(
             classify(
-                &Mapping::new(),
-                &Mapping::new(),
-                &current,
-                &Mapping::new(),
-                &Mapping::new(),
-                &spec(CoreKind::ClashRust, "clash-rs"),
+                ConfigClassificationView {
+                    source: &Mapping::new(),
+                    effective: &Mapping::new(),
+                    spec: &current,
+                },
+                ConfigClassificationView {
+                    source: &Mapping::new(),
+                    effective: &Mapping::new(),
+                    spec: &spec(CoreKind::ClashRust, "clash-rs"),
+                },
             )
             .unwrap(),
             ConfigChange::Switch

--- a/crates/nyanpasu-core-manager/src/health/driver.rs
+++ b/crates/nyanpasu-core-manager/src/health/driver.rs
@@ -192,7 +192,10 @@ mod tests {
     };
 
     use super::*;
-    use crate::probe::{HealthProbe, ProbeFuture};
+    use crate::{
+        health::{HealthPolicySpec, HealthThresholds},
+        probe::{HealthProbe, ProbeFuture},
+    };
 
     fn controller() -> Arc<ResolvedController> {
         Arc::new(ResolvedController {
@@ -202,13 +205,15 @@ mod tests {
     }
 
     fn policy(interval: Duration, timeout: Duration) -> HealthPolicy {
-        HealthPolicy::new(
+        HealthPolicy::new(HealthPolicySpec {
             interval,
             timeout,
-            std::num::NonZeroU32::MIN,
-            std::num::NonZeroU32::MIN,
-            Duration::ZERO,
-        )
+            thresholds: HealthThresholds {
+                failure: std::num::NonZeroU32::MIN,
+                success: std::num::NonZeroU32::MIN,
+            },
+            start_period: Duration::ZERO,
+        })
         .unwrap()
     }
 

--- a/crates/nyanpasu-core-manager/src/health/mod.rs
+++ b/crates/nyanpasu-core-manager/src/health/mod.rs
@@ -18,30 +18,49 @@ pub struct HealthPolicy {
     start_period: Duration,
 }
 
+/// How many consecutive probe results flip the tracker each way. Both are
+/// `NonZeroU32`, so only a name says which direction one belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HealthThresholds {
+    /// Consecutive failures before a healthy instance is called unhealthy.
+    pub failure: NonZeroU32,
+    /// Consecutive successes before an unhealthy instance is called healthy.
+    pub success: NonZeroU32,
+}
+
+/// The five inputs of a [`HealthPolicy`]. They were five positional
+/// parameters over two types — three `Duration`s and two `NonZeroU32` — so
+/// any ordering within either group compiles, and the constructor validates
+/// each value on its own rather than against the slot it landed in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HealthPolicySpec {
+    /// How often the probe runs.
+    pub interval: Duration,
+    /// The budget for a single probe run.
+    pub timeout: Duration,
+    pub thresholds: HealthThresholds,
+    /// A grace window after start during which failures do not count.
+    pub start_period: Duration,
+}
+
 impl HealthPolicy {
-    pub fn new(
-        interval: Duration,
-        timeout: Duration,
-        failure_threshold: NonZeroU32,
-        success_threshold: NonZeroU32,
-        start_period: Duration,
-    ) -> Result<Self, Error> {
-        if interval.is_zero() {
+    pub fn new(spec: HealthPolicySpec) -> Result<Self, Error> {
+        if spec.interval.is_zero() {
             return Err(Error::InvalidHealthPolicy(
                 "interval must be greater than zero".into(),
             ));
         }
-        if timeout.is_zero() {
+        if spec.timeout.is_zero() {
             return Err(Error::InvalidHealthPolicy(
                 "timeout must be greater than zero".into(),
             ));
         }
         Ok(Self {
-            interval,
-            timeout,
-            failure_threshold,
-            success_threshold,
-            start_period,
+            interval: spec.interval,
+            timeout: spec.timeout,
+            failure_threshold: spec.thresholds.failure,
+            success_threshold: spec.thresholds.success,
+            start_period: spec.start_period,
         })
     }
 
@@ -190,36 +209,62 @@ mod tests {
     use std::num::NonZeroU32;
 
     fn policy(failures: u32, successes: u32, start_period: Duration) -> HealthPolicy {
-        HealthPolicy::new(
-            Duration::from_millis(10),
-            Duration::from_millis(20),
-            NonZeroU32::new(failures).unwrap(),
-            NonZeroU32::new(successes).unwrap(),
+        HealthPolicy::new(HealthPolicySpec {
+            interval: Duration::from_millis(10),
+            timeout: Duration::from_millis(20),
+            thresholds: HealthThresholds {
+                failure: NonZeroU32::new(failures).unwrap(),
+                success: NonZeroU32::new(successes).unwrap(),
+            },
             start_period,
-        )
+        })
         .unwrap()
+    }
+
+    #[test]
+    fn policy_keeps_every_input_in_its_own_field() {
+        let policy = HealthPolicy::new(HealthPolicySpec {
+            interval: Duration::from_millis(10),
+            timeout: Duration::from_millis(20),
+            thresholds: HealthThresholds {
+                failure: NonZeroU32::new(3).unwrap(),
+                success: NonZeroU32::new(2).unwrap(),
+            },
+            start_period: Duration::from_millis(30),
+        })
+        .unwrap();
+
+        assert_eq!(policy.interval(), Duration::from_millis(10));
+        assert_eq!(policy.timeout(), Duration::from_millis(20));
+        assert_eq!(policy.failure_threshold(), NonZeroU32::new(3).unwrap());
+        assert_eq!(policy.success_threshold(), NonZeroU32::new(2).unwrap());
+        assert_eq!(policy.start_period(), Duration::from_millis(30));
     }
 
     #[test]
     fn policy_rejects_zero_interval_and_timeout() {
         assert!(
-            HealthPolicy::new(
-                Duration::ZERO,
-                Duration::from_secs(1),
-                NonZeroU32::MIN,
-                NonZeroU32::MIN,
-                Duration::ZERO,
-            )
+            HealthPolicy::new(HealthPolicySpec {
+                interval: Duration::ZERO,
+                timeout: Duration::from_secs(1),
+                thresholds: HealthThresholds {
+                    failure: NonZeroU32::MIN,
+                    success: NonZeroU32::MIN,
+                },
+                start_period: Duration::ZERO,
+            })
             .is_err()
         );
         assert!(
-            HealthPolicy::new(
-                Duration::from_secs(1),
-                Duration::ZERO,
-                NonZeroU32::MIN,
-                NonZeroU32::MIN,
-                Duration::ZERO,
-            )
+            HealthPolicy::new(HealthPolicySpec {
+                interval: Duration::from_secs(1),
+                timeout: Duration::ZERO,
+                thresholds: HealthThresholds {
+                    failure: NonZeroU32::MIN,
+                    success: NonZeroU32::MIN,
+                },
+                start_period: Duration::ZERO,
+            })
             .is_err()
         );
     }

--- a/crates/nyanpasu-core-manager/src/instance.rs
+++ b/crates/nyanpasu-core-manager/src/instance.rs
@@ -261,17 +261,17 @@ impl Instance {
         .await?;
         *shared.supervisor.lock().await = Some(supervisor);
 
-        let monitor = tokio::spawn(monitor_loop(
-            event_rx,
-            shared.clone(),
+        let monitor = tokio::spawn(monitor_loop(MonitorLoopArgs {
+            events: event_rx,
+            shared: shared.clone(),
             epoch,
-            spec.options.clone(),
-            controller.clone(),
+            options: spec.options.clone(),
+            controller: controller.clone(),
             readiness_probe,
             liveness_probe,
             initial_deadline,
-            probe_request_rx,
-        ));
+            probe_requests: probe_request_rx,
+        }));
         *shared.monitor.lock().await = Some(monitor);
 
         Ok(Instance {
@@ -548,9 +548,10 @@ struct RunState {
     tracker: HealthTracker,
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn monitor_loop(
-    mut events: mpsc::UnboundedReceiver<SupervisorEvent>,
+/// Everything the monitor task is started with, so that adding to the set does
+/// not mean threading one more positional argument through the spawn site.
+struct MonitorLoopArgs {
+    events: mpsc::UnboundedReceiver<SupervisorEvent>,
     shared: Arc<Shared>,
     epoch: Epoch,
     options: InstanceOptions,
@@ -558,8 +559,21 @@ async fn monitor_loop(
     readiness_probe: ProbeHandle,
     liveness_probe: Option<ProbeHandle>,
     initial_deadline: Instant,
-    mut probe_requests: mpsc::UnboundedReceiver<ProbeNowRequest>,
-) {
+    probe_requests: mpsc::UnboundedReceiver<ProbeNowRequest>,
+}
+
+async fn monitor_loop(args: MonitorLoopArgs) {
+    let MonitorLoopArgs {
+        mut events,
+        shared,
+        epoch,
+        options,
+        controller,
+        readiness_probe,
+        liveness_probe,
+        initial_deadline,
+        mut probe_requests,
+    } = args;
     let (observation_tx, mut observations) = mpsc::unbounded_channel();
     let mut ever_ready = false;
     let mut timeout_fired = false;
@@ -653,16 +667,17 @@ async fn monitor_loop(
             },
             _ = tokio::time::sleep_until(initial_deadline), if !ever_ready && !timeout_fired => {
                 // Total limit for the initial start, crash-retries included.
-                let became_ready = drain_probe_observations(
-                    &mut observations,
-                    &mut current,
-                    &mut ever_ready,
-                    &mut respawn_deadline,
+                let became_ready = ProbeReconcile {
+                    current: &mut current,
+                    ever_ready: &mut ever_ready,
+                    respawn_deadline: &mut respawn_deadline,
                     initial_deadline,
-                    &shared,
-                    driver.as_ref(),
+                    shared: &shared,
+                    driver: driver.as_ref(),
                     epoch,
-                ).await;
+                }
+                .drain(&mut observations)
+                .await;
                 if !became_ready && !ever_ready {
                     timeout_fired = true;
                     current = None;
@@ -674,16 +689,17 @@ async fn monitor_loop(
                 }
             }
             _ = tokio::time::sleep_until(respawn_deadline_for_select), if respawn_deadline.is_some() => {
-                let became_ready = drain_probe_observations(
-                    &mut observations,
-                    &mut current,
-                    &mut ever_ready,
-                    &mut respawn_deadline,
+                let became_ready = ProbeReconcile {
+                    current: &mut current,
+                    ever_ready: &mut ever_ready,
+                    respawn_deadline: &mut respawn_deadline,
                     initial_deadline,
-                    &shared,
-                    driver.as_ref(),
+                    shared: &shared,
+                    driver: driver.as_ref(),
                     epoch,
-                ).await;
+                }
+                .drain(&mut observations)
+                .await;
                 if !became_ready && respawn_deadline.is_some() {
                     current = None;
                     respawn_deadline = None;
@@ -712,16 +728,17 @@ async fn monitor_loop(
             },
             observation = observations.recv() => {
                 let Some(observation) = observation else { continue };
-                apply_probe_observation(
-                    observation,
-                    &mut current,
-                    &mut ever_ready,
-                    &mut respawn_deadline,
+                ProbeReconcile {
+                    current: &mut current,
+                    ever_ready: &mut ever_ready,
+                    respawn_deadline: &mut respawn_deadline,
                     initial_deadline,
-                    &shared,
-                    driver.as_ref(),
+                    shared: &shared,
+                    driver: driver.as_ref(),
                     epoch,
-                ).await;
+                }
+                .apply(observation)
+                .await;
             }
         }
     }
@@ -731,106 +748,97 @@ fn observation_applies(observation: &ProbeObservation, run: &RunState) -> bool {
     observation.run_id == run.run_id && observation.pid == run.pid
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn apply_probe_observation(
-    observation: ProbeObservation,
-    current: &mut Option<RunState>,
-    ever_ready: &mut bool,
-    respawn_deadline: &mut Option<Instant>,
+/// The state one probe observation reconciles. The three `&mut` fields were
+/// separate parameters that every call site had to keep in the same order;
+/// grouping them makes the loop hand over its readiness state as one thing.
+///
+/// Built per observation inside a `select!` arm and dropped at the end of the
+/// statement, so the borrows never outlive the arm that took them.
+struct ProbeReconcile<'a> {
+    current: &'a mut Option<RunState>,
+    ever_ready: &'a mut bool,
+    respawn_deadline: &'a mut Option<Instant>,
     initial_deadline: Instant,
-    shared: &Shared,
-    driver: Option<&ProbeDriver>,
+    shared: &'a Shared,
+    driver: Option<&'a ProbeDriver>,
     epoch: Epoch,
-) -> bool {
-    let Some(run) = current.as_mut() else {
-        return false;
-    };
-    if !observation_applies(&observation, run) {
-        return false;
-    }
-    let beyond_initial_deadline =
-        !*ever_ready && observation.completed_at > initial_deadline.into_std();
-    let beyond_respawn_deadline =
-        respawn_deadline.is_some_and(|deadline| observation.completed_at > deadline.into_std());
-    if beyond_initial_deadline || beyond_respawn_deadline {
-        return false;
-    }
-
-    tracing::trace!(
-        epoch = epoch.get(),
-        run_id = observation.run_id,
-        pid = observation.pid,
-        phase = ?observation.phase,
-        "applying health probe observation"
-    );
-    let update = run
-        .tracker
-        .observe(observation.completed_at, &observation.result);
-    let should_ack = !run.ack_attempted && update.state == TrackerState::Healthy;
-    if should_ack {
-        run.ack_attempted = true;
-        let pid = run.pid;
-        let supervisor = shared.supervisor.lock().await;
-        let acknowledged = match supervisor.as_ref() {
-            Some(supervisor) => supervisor.acknowledge_ready(pid).await,
-            None => false,
-        };
-        drop(supervisor);
-        if acknowledged {
-            *ever_ready = true;
-            *respawn_deadline = None;
-            if let Some(run) = current.as_mut() {
-                run.ready = true;
-            }
-            if let Some(driver) = driver {
-                driver.use_liveness();
-            }
-            let previous = shared.state_tx.borrow().health.clone();
-            shared.publish_status(InstanceStatus {
-                state: InstanceState::Running { pid },
-                health: Some(health_status(previous.as_ref(), &update, &observation)),
-            });
-        }
-        return acknowledged;
-    }
-
-    let previous = shared.state_tx.borrow().health.clone();
-    let lifecycle = shared.state_tx.borrow().state.clone();
-    shared.publish_status(InstanceStatus {
-        state: lifecycle,
-        health: Some(health_status(previous.as_ref(), &update, &observation)),
-    });
-    false
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn drain_probe_observations(
-    observations: &mut mpsc::UnboundedReceiver<ProbeObservation>,
-    current: &mut Option<RunState>,
-    ever_ready: &mut bool,
-    respawn_deadline: &mut Option<Instant>,
-    initial_deadline: Instant,
-    shared: &Shared,
-    driver: Option<&ProbeDriver>,
-    epoch: Epoch,
-) -> bool {
-    while let Ok(observation) = observations.try_recv() {
-        let became_ready = apply_probe_observation(
-            observation,
-            current,
-            ever_ready,
-            respawn_deadline,
-            initial_deadline,
-            shared,
-            driver,
-            epoch,
-        )
-        .await;
-        if became_ready {
-            return true;
+impl ProbeReconcile<'_> {
+    async fn apply(&mut self, observation: ProbeObservation) -> bool {
+        let Some(run) = self.current.as_mut() else {
+            return false;
+        };
+        if !observation_applies(&observation, run) {
+            return false;
         }
+        let beyond_initial_deadline =
+            !*self.ever_ready && observation.completed_at > self.initial_deadline.into_std();
+        let beyond_respawn_deadline = self
+            .respawn_deadline
+            .is_some_and(|deadline| observation.completed_at > deadline.into_std());
+        if beyond_initial_deadline || beyond_respawn_deadline {
+            return false;
+        }
+
+        tracing::trace!(
+            epoch = self.epoch.get(),
+            run_id = observation.run_id,
+            pid = observation.pid,
+            phase = ?observation.phase,
+            "applying health probe observation"
+        );
+        let update = run
+            .tracker
+            .observe(observation.completed_at, &observation.result);
+        let should_ack = !run.ack_attempted && update.state == TrackerState::Healthy;
+        if should_ack {
+            run.ack_attempted = true;
+            let pid = run.pid;
+            let supervisor = self.shared.supervisor.lock().await;
+            let acknowledged = match supervisor.as_ref() {
+                Some(supervisor) => supervisor.acknowledge_ready(pid).await,
+                None => false,
+            };
+            drop(supervisor);
+            if acknowledged {
+                *self.ever_ready = true;
+                *self.respawn_deadline = None;
+                if let Some(run) = self.current.as_mut() {
+                    run.ready = true;
+                }
+                if let Some(driver) = self.driver {
+                    driver.use_liveness();
+                }
+                let previous = self.shared.state_tx.borrow().health.clone();
+                self.shared.publish_status(InstanceStatus {
+                    state: InstanceState::Running { pid },
+                    health: Some(health_status(previous.as_ref(), &update, &observation)),
+                });
+            }
+            return acknowledged;
+        }
+
+        let previous = self.shared.state_tx.borrow().health.clone();
+        let lifecycle = self.shared.state_tx.borrow().state.clone();
+        self.shared.publish_status(InstanceStatus {
+            state: lifecycle,
+            health: Some(health_status(previous.as_ref(), &update, &observation)),
+        });
+        false
     }
-    false
+
+    async fn drain(
+        &mut self,
+        observations: &mut mpsc::UnboundedReceiver<ProbeObservation>,
+    ) -> bool {
+        while let Ok(observation) = observations.try_recv() {
+            if self.apply(observation).await {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 async fn stop_probe_driver(driver: &mut Option<ProbeDriver>) {
@@ -1066,16 +1074,16 @@ mod tests {
         tokio::time::sleep_until(initial_deadline + Duration::from_millis(1)).await;
 
         assert!(
-            drain_probe_observations(
-                &mut observations,
-                &mut current,
-                &mut ever_ready,
-                &mut respawn_deadline,
+            ProbeReconcile {
+                current: &mut current,
+                ever_ready: &mut ever_ready,
+                respawn_deadline: &mut respawn_deadline,
                 initial_deadline,
-                &shared,
-                None,
-                epoch(1),
-            )
+                shared: &shared,
+                driver: None,
+                epoch: epoch(1),
+            }
+            .drain(&mut observations)
             .await
         );
         assert!(ever_ready);

--- a/crates/nyanpasu-core-manager/src/instance.rs
+++ b/crates/nyanpasu-core-manager/src/instance.rs
@@ -191,7 +191,7 @@ impl Instance {
         if tokio::fs::metadata(&spec.core.binary_path).await.is_err() {
             return Err(Error::BinaryNotFound(spec.core.binary_path.clone()));
         }
-        kind::run_args(spec.core.kind, &spec.working_dir, &spec.config_path)?;
+        kind::run_args(spec.core.kind, spec.core_paths())?;
 
         let readiness_probe = match readiness_probe {
             Some(probe) => probe,
@@ -501,7 +501,7 @@ impl Drop for Instance {
 }
 
 fn build_command(spec: &InstanceSpec, epoch: Epoch, controller: &ResolvedController) -> Command {
-    let mut args = kind::run_args(spec.core.kind, &spec.working_dir, &spec.config_path)
+    let mut args = kind::run_args(spec.core.kind, spec.core_paths())
         .expect("kind validated in Instance::spawn");
     args.extend(kind::controller_args(spec.core.kind, &controller.host));
     let config_dir = spec

--- a/crates/nyanpasu-core-manager/src/kind.rs
+++ b/crates/nyanpasu-core-manager/src/kind.rs
@@ -5,7 +5,10 @@ use std::{ffi::OsString, time::Duration};
 use camino::Utf8Path;
 use nyanpasu_utils::process::ProcessError;
 
-use crate::{error::Error, log::summarize_output};
+use crate::{
+    error::Error,
+    log::{CapturedOutput, summarize_output},
+};
 
 pub use nyanpasu_core_metadata::ClashCoreKind as CoreKind;
 
@@ -141,8 +144,10 @@ async fn run_check(spec: &crate::spec::InstanceSpec, timeout: Duration) -> Resul
     }
     Err(Error::ConfigCheckFailed(summarize_output(
         spec.core.kind,
-        &output.stdout,
-        &output.stderr,
+        CapturedOutput {
+            stdout: &output.stdout,
+            stderr: &output.stderr,
+        },
     )))
 }
 
@@ -204,7 +209,13 @@ mod tests {
         let log = "time=\"2026-07-18T10:00:00Z\" level=info msg=\"start\"\n\
                    time=\"2026-07-18T10:00:01Z\" level=error msg=\"configuration file /x.yaml test failed\"";
         assert_eq!(
-            summarize_output(CoreKind::Mihomo, log, ""),
+            summarize_output(
+                CoreKind::Mihomo,
+                CapturedOutput {
+                    stdout: log,
+                    stderr: "",
+                },
+            ),
             "configuration file /x.yaml test failed"
         );
     }
@@ -212,7 +223,13 @@ mod tests {
     #[test]
     fn check_output_keeps_unrecognized_text() {
         assert_eq!(
-            summarize_output(CoreKind::Mihomo, "plain failure", ""),
+            summarize_output(
+                CoreKind::Mihomo,
+                CapturedOutput {
+                    stdout: "plain failure",
+                    stderr: "",
+                },
+            ),
             "plain failure"
         );
     }
@@ -220,7 +237,13 @@ mod tests {
     #[test]
     fn check_output_no_longer_special_cases_clash_rs() {
         assert_eq!(
-            summarize_output(CoreKind::ClashRust, "", "Error: invalid config"),
+            summarize_output(
+                CoreKind::ClashRust,
+                CapturedOutput {
+                    stdout: "",
+                    stderr: "Error: invalid config",
+                },
+            ),
             "Error: invalid config"
         );
     }

--- a/crates/nyanpasu-core-manager/src/kind.rs
+++ b/crates/nyanpasu-core-manager/src/kind.rs
@@ -22,14 +22,19 @@ const SAFE_PATHS_SEPARATOR: &str = ";";
 #[cfg(not(windows))]
 const SAFE_PATHS_SEPARATOR: &str = ":";
 
+/// The two paths every core is launched with. They are both `Utf8Path` and
+/// were adjacent parameters, so a transposed call produces a well-formed
+/// command line that names the config as the working directory.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CorePaths<'a> {
+    pub working_dir: &'a Utf8Path,
+    pub config_path: &'a Utf8Path,
+}
+
 /// Launch arguments for this kind.
-pub(crate) fn run_args(
-    kind: CoreKind,
-    working_dir: &Utf8Path,
-    config_path: &Utf8Path,
-) -> Result<Vec<OsString>, Error> {
-    let dir = OsString::from(working_dir.as_str());
-    let cfg = OsString::from(config_path.as_str());
+pub(crate) fn run_args(kind: CoreKind, paths: CorePaths<'_>) -> Result<Vec<OsString>, Error> {
+    let dir = OsString::from(paths.working_dir.as_str());
+    let cfg = OsString::from(paths.config_path.as_str());
     Ok(match kind {
         // Meow accepts the mihomo CLI for compatibility.
         CoreKind::Mihomo | CoreKind::Meow => {
@@ -60,13 +65,13 @@ pub(crate) fn controller_args(kind: CoreKind, host: &clash_api::Host) -> Vec<OsS
 
 /// Arguments for a one-shot `-t` config validation run (same for all kinds,
 /// matching the legacy `check_config_`).
-pub(crate) fn check_args(working_dir: &Utf8Path, config_path: &Utf8Path) -> Vec<OsString> {
+pub(crate) fn check_args(paths: CorePaths<'_>) -> Vec<OsString> {
     vec![
         "-t".into(),
         "-d".into(),
-        working_dir.as_str().into(),
+        paths.working_dir.as_str().into(),
         "-f".into(),
-        config_path.as_str().into(),
+        paths.config_path.as_str().into(),
     ]
 }
 
@@ -111,7 +116,7 @@ async fn run_check(spec: &crate::spec::InstanceSpec, timeout: Duration) -> Resul
         .parent()
         .ok_or_else(|| Error::ConfigNotFound(spec.config_path.clone()))?;
     let output = nyanpasu_utils::process::Command::new(spec.core.binary_path.as_str())
-        .args(check_args(&spec.working_dir, &spec.config_path))
+        .args(check_args(spec.core_paths()))
         .env(
             MIHOMO_SAFE_PATHS_ENV_NAME,
             mihomo_safe_paths(&spec.working_dir, config_dir),
@@ -150,17 +155,21 @@ mod tests {
     fn run_args_match_legacy_profiles() {
         let dir = Utf8PathBuf::from("C:/data");
         let cfg = Utf8PathBuf::from("C:/data/config.yaml");
-        let args = run_args(CoreKind::Mihomo, &dir, &cfg).unwrap();
+        let paths = CorePaths {
+            working_dir: &dir,
+            config_path: &cfg,
+        };
+        let args = run_args(CoreKind::Mihomo, paths).unwrap();
         assert_eq!(
             args,
             ["-m", "-d", "C:/data", "-f", "C:/data/config.yaml"].map(OsString::from)
         );
-        let args = run_args(CoreKind::ClashRust, &dir, &cfg).unwrap();
+        let args = run_args(CoreKind::ClashRust, paths).unwrap();
         assert_eq!(
             args,
             ["-d", "C:/data", "-c", "C:/data/config.yaml"].map(OsString::from)
         );
-        let args = run_args(CoreKind::ClashPremium, &dir, &cfg).unwrap();
+        let args = run_args(CoreKind::ClashPremium, paths).unwrap();
         assert_eq!(
             args,
             ["-d", "C:/data", "-f", "C:/data/config.yaml"].map(OsString::from)
@@ -171,9 +180,13 @@ mod tests {
     fn meow_shares_the_mihomo_launch_profile() {
         let dir = Utf8PathBuf::from("/d");
         let cfg = Utf8PathBuf::from("/d/config.yaml");
+        let paths = CorePaths {
+            working_dir: &dir,
+            config_path: &cfg,
+        };
         assert_eq!(
-            run_args(CoreKind::Meow, &dir, &cfg).unwrap(),
-            run_args(CoreKind::Mihomo, &dir, &cfg).unwrap()
+            run_args(CoreKind::Meow, paths).unwrap(),
+            run_args(CoreKind::Mihomo, paths).unwrap()
         );
     }
 

--- a/crates/nyanpasu-core-manager/src/lib.rs
+++ b/crates/nyanpasu-core-manager/src/lib.rs
@@ -30,7 +30,7 @@ pub use control::{
 pub use dns::{DnsController, DnsError, DnsIntent, DnsOverrideRecord, DnsOverrideState};
 pub use epoch::Epoch;
 pub use error::{CoreErrorKind, Error};
-pub use health::{HealthPolicy, probe};
+pub use health::{HealthPolicy, HealthPolicySpec, HealthThresholds, probe};
 pub use instance::{Instance, InstanceBuilder};
 pub use kind::CoreKind;
 pub use log::{LogField, LogFrame, LogLevel, LogStream, LogTimestamp};

--- a/crates/nyanpasu-core-manager/src/log.rs
+++ b/crates/nyanpasu-core-manager/src/log.rs
@@ -288,8 +288,17 @@ pub(crate) fn format_tail<T: Borrow<LogFrame>>(frames: &[T]) -> String {
         .join("\n")
 }
 
+/// The two streams a one-shot run produced. They are both `&str`, so a
+/// transposed call parses stderr as stdout and reports the wrong stream's
+/// last error as the cause of a failed config check.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CapturedOutput<'a> {
+    pub stdout: &'a str,
+    pub stderr: &'a str,
+}
+
 /// Condenses the buffered output of a one-shot run into a single cause.
-pub(crate) fn summarize_output(kind: CoreKind, stdout: &str, stderr: &str) -> String {
+pub(crate) fn summarize_output(kind: CoreKind, output: CapturedOutput<'_>) -> String {
     let mut parser = LogParser::new(kind, 0);
     let mut frames = Vec::new();
     let mut drain = |stream, text: &str| {
@@ -297,22 +306,22 @@ pub(crate) fn summarize_output(kind: CoreKind, stdout: &str, stderr: &str) -> St
             frames.extend(parser.push(stream, line.to_owned()).into_iter().flatten());
         }
     };
-    drain(LogStream::Stdout, stdout);
-    drain(LogStream::Stderr, stderr);
+    drain(LogStream::Stdout, output.stdout);
+    drain(LogStream::Stderr, output.stderr);
     frames.extend(parser.finish().into_iter().flatten());
-    error_summary(&frames).unwrap_or_else(|| verbatim_output(stdout, stderr))
+    error_summary(&frames).unwrap_or_else(|| verbatim_output(output))
 }
 
-fn verbatim_output(stdout: &str, stderr: &str) -> String {
-    let output = [stdout.trim(), stderr.trim()]
+fn verbatim_output(output: CapturedOutput<'_>) -> String {
+    let text = [output.stdout.trim(), output.stderr.trim()]
         .into_iter()
         .filter(|text| !text.is_empty())
         .collect::<Vec<_>>()
         .join("\n");
-    if output.is_empty() {
+    if text.is_empty() {
         "core reported no output".to_owned()
     } else {
-        output
+        text
     }
 }
 
@@ -1299,8 +1308,10 @@ mod tests {
         assert_eq!(
             summarize_output(
                 CoreKind::Mihomo,
-                r#"time="2026-07-29T00:17:26.518376100+08:00" level=fatal msg="Parse config error: yaml: line 2: did not find expected node content""#,
-                "",
+                CapturedOutput {
+                    stdout: r#"time="2026-07-29T00:17:26.518376100+08:00" level=fatal msg="Parse config error: yaml: line 2: did not find expected node content""#,
+                    stderr: "",
+                },
             ),
             "Parse config error: yaml: line 2: did not find expected node content"
         );
@@ -1308,16 +1319,20 @@ mod tests {
         assert_eq!(
             summarize_output(
                 CoreKind::ClashPremium,
-                "00:16:30 INF [MMDB] can't find DB\n00:17:26 FTL [Config] parse config failed error=yaml: line 2: did not find expected node content",
-                "",
+                CapturedOutput {
+                    stdout: "00:16:30 INF [MMDB] can't find DB\n00:17:26 FTL [Config] parse config failed error=yaml: line 2: did not find expected node content",
+                    stderr: "",
+                },
             ),
             "parse config failed error=yaml: line 2: did not find expected node content"
         );
 
         let meow = summarize_output(
             CoreKind::Meow,
-            "\u{1b}[2m2026-07-28T16:17:26.719459Z\u{1b}[0m \u{1b}[31mERROR\u{1b}[0m \u{1b}[2mmeow\u{1b}[0m\u{1b}[2m:\u{1b}[0m meow-rs stopped with an error \u{1b}[3merror\u{1b}[0m\u{1b}[2m=\u{1b}[0mdid not find expected node content at line 3 column 1",
-            "warning: --geodata-mode is not supported and will be ignored\nError: did not find expected node content at line 3 column 1, while parsing a flow node",
+            CapturedOutput {
+                stdout: "\u{1b}[2m2026-07-28T16:17:26.719459Z\u{1b}[0m \u{1b}[31mERROR\u{1b}[0m \u{1b}[2mmeow\u{1b}[0m\u{1b}[2m:\u{1b}[0m meow-rs stopped with an error \u{1b}[3merror\u{1b}[0m\u{1b}[2m=\u{1b}[0mdid not find expected node content at line 3 column 1",
+                stderr: "warning: --geodata-mode is not supported and will be ignored\nError: did not find expected node content at line 3 column 1, while parsing a flow node",
+            },
         );
         assert!(
             meow.contains("did not find expected node content"),
@@ -1326,8 +1341,10 @@ mod tests {
 
         let clash_rs = summarize_output(
             CoreKind::ClashRust,
-            "",
-            "Error: invalid config: couldn't not parse config content mixed-port: not-a-port\nproxies: [[[\n: did not find expected node content at line 3 column 1, while parsing a flow node",
+            CapturedOutput {
+                stdout: "",
+                stderr: "Error: invalid config: couldn't not parse config content mixed-port: not-a-port\nproxies: [[[\n: did not find expected node content at line 3 column 1, while parsing a flow node",
+            },
         );
         assert!(clash_rs.contains("invalid config"), "{clash_rs}");
         assert!(clash_rs.contains("proxies: [[["), "{clash_rs}");
@@ -1336,11 +1353,23 @@ mod tests {
     #[test]
     fn summary_falls_back_to_verbatim_output() {
         assert_eq!(
-            summarize_output(CoreKind::Mihomo, "  ", ""),
+            summarize_output(
+                CoreKind::Mihomo,
+                CapturedOutput {
+                    stdout: "  ",
+                    stderr: "",
+                },
+            ),
             "core reported no output"
         );
         assert_eq!(
-            summarize_output(CoreKind::Mihomo, "unstructured note", ""),
+            summarize_output(
+                CoreKind::Mihomo,
+                CapturedOutput {
+                    stdout: "unstructured note",
+                    stderr: "",
+                },
+            ),
             "unstructured note"
         );
     }

--- a/crates/nyanpasu-core-manager/src/manager/apply.rs
+++ b/crates/nyanpasu-core-manager/src/manager/apply.rs
@@ -53,12 +53,8 @@ impl CoreManager {
             .prepare_apply(current, input.clone(), &snapshot)
             .await?;
         let change = mihomo::classify(
-            &current.plan.source_document,
-            &current.plan.effective_document,
-            &current.plan.source_spec,
-            &prepared.plan.source_document,
-            &prepared.plan.effective_document,
-            &prepared.plan.source_spec,
+            current.plan.classification_view(),
+            prepared.plan.classification_view(),
         )?;
         if matches!(change, ConfigChange::Noop) {
             return Ok(ApplyOutcome::Noop {

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -196,6 +196,16 @@ struct EpochPlan {
     effective_document: Mapping,
 }
 
+impl EpochPlan {
+    fn classification_view(&self) -> mihomo::ConfigClassificationView<'_> {
+        mihomo::ConfigClassificationView {
+            source: &self.source_document,
+            effective: &self.effective_document,
+            spec: &self.source_spec,
+        }
+    }
+}
+
 struct Active {
     instance: Box<dyn RuntimeInstance>,
     forwarder: tokio::task::JoinHandle<()>,

--- a/crates/nyanpasu-core-manager/src/manager/switching.rs
+++ b/crates/nyanpasu-core-manager/src/manager/switching.rs
@@ -334,7 +334,7 @@ impl CoreManager {
         if tokio::fs::metadata(&spec.core.binary_path).await.is_err() {
             return Err(Error::BinaryNotFound(spec.core.binary_path.clone()));
         }
-        crate::kind::run_args(spec.core.kind, &spec.working_dir, &spec.config_path)?;
+        crate::kind::run_args(spec.core.kind, spec.core_paths())?;
         Ok(())
     }
 

--- a/crates/nyanpasu-core-manager/src/spec.rs
+++ b/crates/nyanpasu-core-manager/src/spec.rs
@@ -28,6 +28,15 @@ pub struct InstanceSpec {
     pub options: InstanceOptions,
 }
 
+impl InstanceSpec {
+    pub(crate) fn core_paths(&self) -> crate::kind::CorePaths<'_> {
+        crate::kind::CorePaths {
+            working_dir: &self.working_dir,
+            config_path: &self.config_path,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct InstanceOptions {
     /// Total limit for the initial start (spawn → readiness threshold).

--- a/crates/nyanpasu-core-manager/tests/common/mod.rs
+++ b/crates/nyanpasu-core-manager/tests/common/mod.rs
@@ -8,7 +8,8 @@ use std::{sync::Arc, time::Duration};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_core_manager::{
-    CoreKind, CoreSpec, Epoch, HealthPolicy, InstanceOptions, InstanceSpec,
+    CoreKind, CoreSpec, Epoch, HealthPolicy, HealthPolicySpec, HealthThresholds, InstanceOptions,
+    InstanceSpec,
     state::{HealthState, InstanceState, InstanceStatus},
 };
 use nyanpasu_utils::process::{Backoff, RestartPolicy};
@@ -39,13 +40,15 @@ pub fn free_port() -> u16 {
 pub fn fast_options() -> InstanceOptions {
     InstanceOptions {
         startup_timeout: Duration::from_secs(5),
-        health: HealthPolicy::new(
-            Duration::from_millis(50),
-            Duration::from_secs(1),
-            std::num::NonZeroU32::new(3).unwrap(),
-            std::num::NonZeroU32::MIN,
-            Duration::ZERO,
-        )
+        health: HealthPolicy::new(HealthPolicySpec {
+            interval: Duration::from_millis(50),
+            timeout: Duration::from_secs(1),
+            thresholds: HealthThresholds {
+                failure: std::num::NonZeroU32::new(3).unwrap(),
+                success: std::num::NonZeroU32::MIN,
+            },
+            start_period: Duration::ZERO,
+        })
         .unwrap(),
         restart_policy: RestartPolicy::OnFailure { max_restarts: 2 },
         backoff: Backoff::exponential(Duration::from_millis(50), Duration::from_millis(200)),

--- a/crates/nyanpasu-core-manager/tests/instance_lifecycle.rs
+++ b/crates/nyanpasu-core-manager/tests/instance_lifecycle.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use nyanpasu_core_manager::{
-    HealthPolicy, ProbeHandle, ProbePhase, ProbeResult,
+    HealthPolicy, HealthPolicySpec, HealthThresholds, ProbeHandle, ProbePhase, ProbeResult,
     instance::Instance,
     spec::ResolvedController,
     state::{HealthState, InstanceState},
@@ -329,13 +329,15 @@ async fn custom_readiness_and_success_threshold_gate_running() {
     let port = common::free_port();
     let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
     let mut spec = common::mihomo_spec(&dir, config);
-    spec.options.health = HealthPolicy::new(
-        Duration::from_millis(20),
-        Duration::from_secs(1),
-        NonZeroU32::new(3).unwrap(),
-        NonZeroU32::new(3).unwrap(),
-        Duration::ZERO,
-    )
+    spec.options.health = HealthPolicy::new(HealthPolicySpec {
+        interval: Duration::from_millis(20),
+        timeout: Duration::from_secs(1),
+        thresholds: HealthThresholds {
+            failure: NonZeroU32::new(3).unwrap(),
+            success: NonZeroU32::new(3).unwrap(),
+        },
+        start_period: Duration::ZERO,
+    })
     .unwrap();
     let calls = Arc::new(AtomicUsize::new(0));
     let probe = ProbeHandle::from_fn("threshold-readiness", {
@@ -371,13 +373,15 @@ async fn liveness_is_off_by_default_after_custom_readiness() {
     let port = common::free_port();
     let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
     let mut spec = common::mihomo_spec(&dir, config);
-    spec.options.health = HealthPolicy::new(
-        Duration::from_millis(20),
-        Duration::from_secs(1),
-        NonZeroU32::new(3).unwrap(),
-        NonZeroU32::MIN,
-        Duration::ZERO,
-    )
+    spec.options.health = HealthPolicy::new(HealthPolicySpec {
+        interval: Duration::from_millis(20),
+        timeout: Duration::from_secs(1),
+        thresholds: HealthThresholds {
+            failure: NonZeroU32::new(3).unwrap(),
+            success: NonZeroU32::MIN,
+        },
+        start_period: Duration::ZERO,
+    })
     .unwrap();
     let calls = Arc::new(AtomicUsize::new(0));
     let probe = ProbeHandle::from_fn("readiness-only", {
@@ -410,13 +414,15 @@ async fn readiness_probe_can_be_reused_for_liveness() {
     let port = common::free_port();
     let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
     let mut spec = common::mihomo_spec(&dir, config);
-    spec.options.health = HealthPolicy::new(
-        Duration::from_millis(20),
-        Duration::from_secs(1),
-        NonZeroU32::MIN,
-        NonZeroU32::MIN,
-        Duration::ZERO,
-    )
+    spec.options.health = HealthPolicy::new(HealthPolicySpec {
+        interval: Duration::from_millis(20),
+        timeout: Duration::from_secs(1),
+        thresholds: HealthThresholds {
+            failure: NonZeroU32::MIN,
+            success: NonZeroU32::MIN,
+        },
+        start_period: Duration::ZERO,
+    })
     .unwrap();
     let phases = Arc::new(parking_lot::Mutex::new(Vec::new()));
     let probe = ProbeHandle::from_fn("shared-probe", {
@@ -455,13 +461,15 @@ async fn liveness_hysteresis_is_observe_only_and_recovers() {
     let port = common::free_port();
     let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
     let mut spec = common::mihomo_spec(&dir, config);
-    spec.options.health = HealthPolicy::new(
-        Duration::from_millis(20),
-        Duration::from_secs(1),
-        NonZeroU32::new(2).unwrap(),
-        NonZeroU32::new(2).unwrap(),
-        Duration::ZERO,
-    )
+    spec.options.health = HealthPolicy::new(HealthPolicySpec {
+        interval: Duration::from_millis(20),
+        timeout: Duration::from_secs(1),
+        thresholds: HealthThresholds {
+            failure: NonZeroU32::new(2).unwrap(),
+            success: NonZeroU32::new(2).unwrap(),
+        },
+        start_period: Duration::ZERO,
+    })
     .unwrap();
     let readiness = ProbeHandle::from_fn("ready", |_| async { ProbeResult::Healthy });
     let failures_remaining = Arc::new(AtomicUsize::new(0));
@@ -546,13 +554,15 @@ async fn absolute_startup_deadline_rejects_late_probe_success() {
     let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
     let mut spec = common::mihomo_spec(&dir, config);
     spec.options.startup_timeout = Duration::from_millis(120);
-    spec.options.health = HealthPolicy::new(
-        Duration::from_millis(10),
-        Duration::from_secs(1),
-        NonZeroU32::MIN,
-        NonZeroU32::MIN,
-        Duration::from_secs(1),
-    )
+    spec.options.health = HealthPolicy::new(HealthPolicySpec {
+        interval: Duration::from_millis(10),
+        timeout: Duration::from_secs(1),
+        thresholds: HealthThresholds {
+            failure: NonZeroU32::MIN,
+            success: NonZeroU32::MIN,
+        },
+        start_period: Duration::from_secs(1),
+    })
     .unwrap();
     let probe = ProbeHandle::from_fn("late-success", |_| async {
         tokio::time::sleep(Duration::from_millis(400)).await;
@@ -582,13 +592,15 @@ async fn stop_cancels_a_hanging_liveness_probe() {
     let port = common::free_port();
     let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
     let mut spec = common::mihomo_spec(&dir, config);
-    spec.options.health = HealthPolicy::new(
-        Duration::from_millis(10),
-        Duration::from_secs(5),
-        NonZeroU32::MIN,
-        NonZeroU32::MIN,
-        Duration::ZERO,
-    )
+    spec.options.health = HealthPolicy::new(HealthPolicySpec {
+        interval: Duration::from_millis(10),
+        timeout: Duration::from_secs(5),
+        thresholds: HealthThresholds {
+            failure: NonZeroU32::MIN,
+            success: NonZeroU32::MIN,
+        },
+        start_period: Duration::ZERO,
+    })
     .unwrap();
     let started = Arc::new(tokio::sync::Notify::new());
     let liveness = ProbeHandle::from_fn("hanging", {
@@ -690,13 +702,15 @@ async fn exited_run_cancels_its_in_flight_probe_before_replacement() {
     );
     let mut spec = common::mihomo_spec(&dir, config);
     spec.options.startup_timeout = Duration::from_millis(450);
-    spec.options.health = HealthPolicy::new(
-        Duration::from_millis(5),
-        Duration::from_secs(1),
-        NonZeroU32::MIN,
-        NonZeroU32::MIN,
-        Duration::ZERO,
-    )
+    spec.options.health = HealthPolicy::new(HealthPolicySpec {
+        interval: Duration::from_millis(5),
+        timeout: Duration::from_secs(1),
+        thresholds: HealthThresholds {
+            failure: NonZeroU32::MIN,
+            success: NonZeroU32::MIN,
+        },
+        start_period: Duration::ZERO,
+    })
     .unwrap();
     let first_pid = Arc::new(parking_lot::Mutex::new(None));
     let probe = ProbeHandle::from_fn("late-first-run", {

--- a/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
+++ b/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
@@ -10,8 +10,9 @@ use std::{
 };
 
 use nyanpasu_core_manager::{
-    CoreState, Error, HealthPolicy, HealthState, LocalIpcPolicy, LogLevel, LogStream,
-    ManagerOptions, ProbeHandle, ProbeResult, StopReason, manager::CoreManager,
+    CoreState, Error, HealthPolicy, HealthPolicySpec, HealthState, HealthThresholds,
+    LocalIpcPolicy, LogLevel, LogStream, ManagerOptions, ProbeHandle, ProbeResult, StopReason,
+    manager::CoreManager,
 };
 
 async fn manager(runtime_dir: &camino::Utf8Path) -> CoreManager {
@@ -29,13 +30,15 @@ async fn manager_builder_forwards_atomic_runtime_health_without_bumping_lifecycl
     let port = common::free_port();
     let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
     let mut spec = common::mihomo_spec(&dir, config);
-    spec.options.health = HealthPolicy::new(
-        Duration::from_millis(20),
-        Duration::from_secs(1),
-        NonZeroU32::new(2).unwrap(),
-        NonZeroU32::MIN,
-        Duration::ZERO,
-    )
+    spec.options.health = HealthPolicy::new(HealthPolicySpec {
+        interval: Duration::from_millis(20),
+        timeout: Duration::from_secs(1),
+        thresholds: HealthThresholds {
+            failure: NonZeroU32::new(2).unwrap(),
+            success: NonZeroU32::MIN,
+        },
+        start_period: Duration::ZERO,
+    })
     .unwrap();
     let readiness_calls = Arc::new(AtomicUsize::new(0));
     let readiness = ProbeHandle::from_fn("manager-readiness", {


### PR DESCRIPTION
Removes five *signature transposition* defects in `nyanpasu-core-manager`: call
sites where same-typed parameters can be swapped, still compile, still run, and
produce a wrong result that nothing reports.

Each commit replaces positional same-typed parameters with a named struct or a
borrowed view. No behaviour changes.

| Commit | Before | After |
|---|---|---|
| `classify config changes from two plan views` | `classify` took six interleaved refs — source doc, effective doc, spec, once per side | two `ConfigClassificationView`s, built by `EpochPlan::classification_view()` |
| `reconcile probe observations through one state view` | two 8-parameter probe helpers, plus `monitor_loop`'s 9 | `ProbeReconcile::{apply,drain}` and `MonitorLoopArgs` |
| `take HealthPolicy inputs by name` | `HealthPolicy::new` — three `Duration`, two `NonZeroU32`, all positional | `HealthPolicySpec` + `HealthThresholds` |
| `pass core launch paths as one view` | `run_args`/`check_args(working_dir, config_path)` | `CorePaths`, via `InstanceSpec::core_paths()` |
| `name captured stdout and stderr` | `summarize_output(kind, stdout, stderr)` | `CapturedOutput` |

## Notes

- **Three `#[allow(clippy::too_many_arguments)]` are gone.** `ProbeReconcile`
  holds three `&mut` across `.await`; it is built inside the `select!` arm that
  needs it and dropped at the end of the statement, so the borrows never
  outlive the arm or collide with the arms that stop the driver.
- `classify`'s two views are the same type and can still be swapped wholesale.
  That is inherent to comparing two snapshots; what is gone is the six-way
  interleaving, and the sole production call site now names two plans instead
  of six of their fields.
- `HealthPolicy::new` is `pub` (hence `!`). Most existing tests set both
  thresholds to the same value, so a transposition was invisible to them — a
  new test reads all five fields back with five distinct values.
- `run_args`/`check_args` keep a view rather than swallowing `&InstanceSpec`, so
  the legacy comparison tests can still build the pair from two bare paths.
  Those tests pin the emitted argument vectors, which are byte-identical.
- Two `README.md` examples still called the five-argument `HealthPolicy::new`.
  The README is not a doctest, so nothing would have caught them going stale;
  they are updated in the same commit.

## Verification

`cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets
--all-features` are clean (one pre-existing `unused variable: debug` warning in
`nyanpasu-service-runtime`). `cargo test --workspace --all-features`: 40 test
targets, 456 passed, 0 failed.

`git diff` touches no `nyanpasu_ipc/**`, no route, and no CLI argument.

Every rewritten call site was checked against its pre-image; no field changed
which value it reads.

https://claude.ai/code/session_01BsiU6nsZN2i4fcNntm2xZd
