### PR TITLE
refactor(service-runtime, clash-api)!: name the transposable directory, install and retry inputs

### DIFF
--- a/crates/clash-api/src/api/mod.rs
+++ b/crates/clash-api/src/api/mod.rs
@@ -25,7 +25,7 @@ pub use maintenance::{Hello, StatusResponse, UpgradeOptions};
 pub use memory::Memory;
 pub use proxies::{
     Delay, DelayHistory, DelayQuery, ExpectedStatus, ProviderName, ProviderType, Proxy, ProxyExtra,
-    ProxyName, ProxyProvider, SubscriptionInfo, VehicleType,
+    ProxyName, ProxyProvider, ProxySelection, SubscriptionInfo, VehicleType,
 };
 pub use rules::{
     Rule, RuleExtra, RuleFormat, RulePatch, RuleProvider, RuleProviderBehavior, RuleProviderName,

--- a/crates/clash-api/src/api/proxies.rs
+++ b/crates/clash-api/src/api/proxies.rs
@@ -10,6 +10,14 @@ use crate::{Client, Error, Result, retry::RequestMetadata};
 #[serde(transparent)]
 pub struct ProxyName(String);
 
+/// Which node to select, and in which group. Both sides are `ProxyName`, so
+/// only a name tells the group apart from the node inside it.
+#[derive(Debug, Clone, Copy)]
+pub struct ProxySelection<'a> {
+    pub group: &'a ProxyName,
+    pub target: &'a ProxyName,
+}
+
 impl ProxyName {
     pub fn new(value: impl Into<String>) -> Self {
         Self(value.into())
@@ -335,7 +343,8 @@ impl Client {
         .await
     }
 
-    pub async fn select_proxy(&self, group: &ProxyName, target: &ProxyName) -> Result<()> {
+    pub async fn select_proxy(&self, selection: ProxySelection<'_>) -> Result<()> {
+        let ProxySelection { group, target } = selection;
         let url = self.endpoint_with_segments("/proxies", [group.as_str(), ""])?;
         self.send_empty(
             RequestMetadata::new("select_proxy", Method::PUT, false),

--- a/crates/clash-api/src/lib.rs
+++ b/crates/clash-api/src/lib.rs
@@ -10,11 +10,11 @@ pub use api::{
     DelayHistory, DelayQuery, DnsMode, DnsQuery, DnsQuestion, DnsRecord, DnsRecordType,
     DnsResponse, ExpectedStatus, FindProcessMode, GeoUrls, Hello, LogEntry, LogField, LogLevel,
     LogQuery, Memory, MuxOptions, ProviderName, ProviderType, Proxy, ProxyExtra, ProxyName,
-    ProxyProvider, Rule, RuleExtra, RuleFormat, RulePatch, RuleProvider, RuleProviderBehavior,
-    RuleProviderName, RuntimeConfig, RuntimeTuicServer, RuntimeTun, StatusResponse, StorageKey,
-    StructuredLogEntry, StructuredLogLevel, SubscriptionInfo, Traffic, TuicServerPatch, TunPatch,
-    TunStack, TunnelMode, UpdateConfigOptions, UpdateConfigRequest, UpgradeOptions, VehicleType,
-    Version,
+    ProxyProvider, ProxySelection, Rule, RuleExtra, RuleFormat, RulePatch, RuleProvider,
+    RuleProviderBehavior, RuleProviderName, RuntimeConfig, RuntimeTuicServer, RuntimeTun,
+    StatusResponse, StorageKey, StructuredLogEntry, StructuredLogLevel, SubscriptionInfo, Traffic,
+    TuicServerPatch, TunPatch, TunStack, TunnelMode, UpdateConfigOptions, UpdateConfigRequest,
+    UpgradeOptions, VehicleType, Version,
 };
 pub use client::{Client, ClientBuilder, ControllerEndpoint, Host, Secret};
 pub use error::{Error, ErrorBody, Result};

--- a/crates/clash-api/src/lib.rs
+++ b/crates/clash-api/src/lib.rs
@@ -19,7 +19,7 @@ pub use api::{
 pub use client::{Client, ClientBuilder, ControllerEndpoint, Host, Secret};
 pub use error::{Error, ErrorBody, Result};
 pub use indexmap::IndexMap;
-pub use retry::{ExponentialRetry, NoRetry, RequestMetadata, RetryPolicy};
+pub use retry::{DelayRange, ExponentialRetry, NoRetry, RequestMetadata, RetryPolicy};
 pub use stream::HttpStream;
 
 // TODO(ws-typed-stream): consider an opt-in typed frame adapter after raw

--- a/crates/clash-api/src/retry.rs
+++ b/crates/clash-api/src/retry.rs
@@ -68,6 +68,16 @@ pub struct ExponentialRetry {
     jitter: bool,
 }
 
+/// The two ends of an exponential schedule, before jitter. Both are
+/// `Duration`, so only a name says which end a value belongs to.
+#[derive(Debug, Clone, Copy)]
+pub struct DelayRange {
+    /// The base delay before the first retry.
+    pub min: Duration,
+    /// The cap that the doubling base delay saturates at.
+    pub max: Duration,
+}
+
 impl ExponentialRetry {
     /// A conservative policy suitable for a controller running on the same machine.
     pub const fn conservative() -> Self {
@@ -79,11 +89,15 @@ impl ExponentialRetry {
         }
     }
 
-    pub const fn new(max_retries: usize, min_delay: Duration, max_delay: Duration) -> Self {
+    pub const fn new(max_retries: usize, delay: DelayRange) -> Self {
+        debug_assert!(
+            delay.min.as_nanos() <= delay.max.as_nanos(),
+            "retry delay ceiling is below its floor"
+        );
         Self {
             max_retries,
-            min_delay,
-            max_delay,
+            min_delay: delay.min,
+            max_delay: delay.max,
             jitter: false,
         }
     }
@@ -156,7 +170,13 @@ mod tests {
 
     #[test]
     fn exponential_retry_produces_exactly_the_configured_extra_attempts() {
-        let policy = ExponentialRetry::new(2, Duration::from_millis(1), Duration::from_millis(2));
+        let policy = ExponentialRetry::new(
+            2,
+            DelayRange {
+                min: Duration::from_millis(1),
+                max: Duration::from_millis(2),
+            },
+        );
         let metadata = RequestMetadata::new("version", Method::GET, true);
 
         assert_eq!(policy.delays(&metadata).count(), 2);

--- a/crates/clash-api/tests/mihomo.rs
+++ b/crates/clash-api/tests/mihomo.rs
@@ -23,9 +23,9 @@ use axum::{
 };
 use clash_api::{
     Client, ConfigPatch, Connection, ConnectionStreamQuery, DelayQuery, DnsQuery, DnsRecordType,
-    ExpectedStatus, Host, LogEntry, LogLevel, LogQuery, Memory, ProviderName, ProxyName, RulePatch,
-    RuleProviderName, StorageKey, StructuredLogEntry, Traffic, TunnelMode, UpdateConfigOptions,
-    UpdateConfigRequest, UpgradeOptions,
+    ExpectedStatus, Host, LogEntry, LogLevel, LogQuery, Memory, ProviderName, ProxyName,
+    ProxySelection, RulePatch, RuleProviderName, StorageKey, StructuredLogEntry, Traffic,
+    TunnelMode, UpdateConfigOptions, UpdateConfigRequest, UpgradeOptions,
 };
 use futures_util::{StreamExt, stream};
 use reqwest_websocket::Message;
@@ -477,7 +477,10 @@ async fn assert_proxy_and_rule_apis(client: &Client, healthcheck_url: &str) {
     );
 
     client
-        .select_proxy(&ProxyName::from(GROUP), &ProxyName::from(REJECT))
+        .select_proxy(ProxySelection {
+            group: &ProxyName::from(GROUP),
+            target: &ProxyName::from(REJECT),
+        })
         .await
         .unwrap();
     assert_eq!(
@@ -485,7 +488,10 @@ async fn assert_proxy_and_rule_apis(client: &Client, healthcheck_url: &str) {
         Some(ProxyName::from(REJECT))
     );
     client
-        .select_proxy(&ProxyName::from(GROUP), &ProxyName::from(DIRECT))
+        .select_proxy(ProxySelection {
+            group: &ProxyName::from(GROUP),
+            target: &ProxyName::from(DIRECT),
+        })
         .await
         .unwrap();
 

--- a/crates/clash-api/tests/rest.rs
+++ b/crates/clash-api/tests/rest.rs
@@ -5,8 +5,8 @@ use axum::{
     routing::{get, put},
 };
 use clash_api::{
-    Client, ConfigPatch, Host, ProviderName, ProxyName, StorageKey, UpdateConfigOptions,
-    UpdateConfigRequest, UpgradeOptions,
+    Client, ConfigPatch, Host, ProviderName, ProxyName, ProxySelection, StorageKey,
+    UpdateConfigOptions, UpdateConfigRequest, UpgradeOptions,
 };
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -92,7 +92,10 @@ async fn typed_rest_methods_preserve_queries_bodies_and_empty_responses() {
         .await
         .unwrap();
     client
-        .select_proxy(&ProxyName::from("GLOBAL/日本"), &ProxyName::from("DIRECT"))
+        .select_proxy(ProxySelection {
+            group: &ProxyName::from("GLOBAL/日本"),
+            target: &ProxyName::from("DIRECT"),
+        })
         .await
         .unwrap();
     server.abort();

--- a/crates/clash-api/tests/traffic.rs
+++ b/crates/clash-api/tests/traffic.rs
@@ -15,7 +15,7 @@ use axum::{
     response::{IntoResponse, Response},
     routing::get,
 };
-use clash_api::{Client, Error, ExponentialRetry, Host, Traffic};
+use clash_api::{Client, DelayRange, Error, ExponentialRetry, Host, Traffic};
 use futures_util::{StreamExt, stream};
 use reqwest_websocket::Message;
 
@@ -117,8 +117,10 @@ async fn retry_policy_retries_only_transient_request_errors() {
     let client = Client::builder(Host::http(address).unwrap())
         .retry_policy(ExponentialRetry::new(
             2,
-            Duration::from_millis(1),
-            Duration::from_millis(1),
+            DelayRange {
+                min: Duration::from_millis(1),
+                max: Duration::from_millis(1),
+            },
         ))
         .build()
         .unwrap();
@@ -157,8 +159,10 @@ async fn retry_policy_covers_the_websocket_handshake_but_not_the_open_socket() {
     let client = Client::builder(Host::http(address).unwrap())
         .retry_policy(ExponentialRetry::new(
             2,
-            Duration::from_millis(1),
-            Duration::from_millis(1),
+            DelayRange {
+                min: Duration::from_millis(1),
+                max: Duration::from_millis(1),
+            },
         ))
         .build()
         .unwrap();
@@ -187,8 +191,10 @@ async fn unauthorized_response_is_not_retried_and_retains_mihomo_message() {
     let client = Client::builder(Host::http(address).unwrap())
         .retry_policy(ExponentialRetry::new(
             3,
-            Duration::from_millis(1),
-            Duration::from_millis(1),
+            DelayRange {
+                min: Duration::from_millis(1),
+                max: Duration::from_millis(1),
+            },
         ))
         .build()
         .unwrap();

--- a/crates/nyanpasu-service-runtime/src/cmds/install.rs
+++ b/crates/nyanpasu-service-runtime/src/cmds/install.rs
@@ -112,8 +112,10 @@ pub fn install_with(manager: &dyn ServiceManager, ctx: InstallCommand) -> Result
     tracing::info!("Installing service...");
     manager.install(build_install_ctx(
         label.clone(),
-        service_binary,
-        service_data_dir,
+        InstallPaths {
+            program: service_binary,
+            working_directory: service_data_dir,
+        },
         &ctx,
         envs,
     ))?;
@@ -144,16 +146,24 @@ pub(super) fn policy_value(policy: LocalIpcPolicyArg) -> &'static str {
     }
 }
 
-fn build_install_ctx(
-    label: ServiceLabel,
+/// The two paths the service definition is written with. Both are `PathBuf`
+/// and were adjacent parameters, so a transposition compiles and is persisted
+/// into the OS service manager: the daemon is registered to launch a directory
+/// and to run out of its own binary.
+struct InstallPaths {
     program: PathBuf,
     working_directory: PathBuf,
+}
+
+fn build_install_ctx(
+    label: ServiceLabel,
+    paths: InstallPaths,
     ctx: &InstallCommand,
     environment: Vec<(String, String)>,
 ) -> ServiceInstallCtx {
     ServiceInstallCtx {
         label,
-        program,
+        program: paths.program,
         args: vec![
             OsString::from("server"),
             OsString::from("--nyanpasu-data-dir"),
@@ -168,7 +178,7 @@ fn build_install_ctx(
         ],
         contents: None,
         username: None, // because we just need to run the service as root
-        working_directory: Some(working_directory),
+        working_directory: Some(paths.working_directory),
         environment: Some(environment),
         autostart: true,
         restart_policy: RestartPolicy::default(),
@@ -228,8 +238,10 @@ mod tests {
         let environment = vec![("HOME".into(), "home".into())];
         let install_ctx = build_install_ctx(
             label(),
-            PathBuf::from("program"),
-            PathBuf::from("working-directory"),
+            InstallPaths {
+                program: PathBuf::from("program"),
+                working_directory: PathBuf::from("working-directory"),
+            },
             &ctx,
             environment.clone(),
         );

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -170,21 +170,30 @@ pub struct CoreManagerService {
     inner: Arc<Inner>,
 }
 
+/// The two directories the service runs out of. They are both `Utf8PathBuf`
+/// and were passed on either side of the IPC policy, so only a name says
+/// which root the manager owns and which one belongs to the application.
+pub struct ServiceDirs {
+    /// Where the core manager keeps its runtime state and staged sources.
+    pub runtime: Utf8PathBuf,
+    /// The Nyanpasu application data directory.
+    pub data: Utf8PathBuf,
+}
+
 impl CoreManagerService {
     pub async fn new(
-        runtime_dir: Utf8PathBuf,
+        dirs: ServiceDirs,
         local_ipc_policy: LocalIpcPolicy,
-        data_dir: Utf8PathBuf,
     ) -> Result<Self, anyhow::Error> {
-        let source_dir = runtime_dir.join("v2-sources");
+        let source_dir = dirs.runtime.join("v2-sources");
         let manager = Manager::new(ManagerOptions {
-            runtime_dir: Some(runtime_dir),
+            runtime_dir: Some(dirs.runtime),
             local_ipc_policy,
             ..ManagerOptions::default()
         })
         .await?;
         let core_control =
-            CoreControl::spawn(manager.clone(), ControlOptions::new(source_dir, data_dir));
+            CoreControl::spawn(manager.clone(), ControlOptions::new(source_dir, dirs.data));
         Ok(Self {
             inner: Arc::new(Inner {
                 manager,
@@ -1512,9 +1521,15 @@ mod tests {
             .expect("temp path is UTF-8");
         let data_dir = Utf8PathBuf::from_path_buf(dir.path().join("nyanpasu-data"))
             .expect("temp path is UTF-8");
-        let service = CoreManagerService::new(runtime_dir, LocalIpcPolicy::Disable, data_dir)
-            .await
-            .expect("the manager builds on a fresh runtime dir");
+        let service = CoreManagerService::new(
+            ServiceDirs {
+                runtime: runtime_dir,
+                data: data_dir,
+            },
+            LocalIpcPolicy::Disable,
+        )
+        .await
+        .expect("the manager builds on a fresh runtime dir");
         (dir, service)
     }
 

--- a/crates/nyanpasu-service-runtime/src/server/mod.rs
+++ b/crates/nyanpasu-service-runtime/src/server/mod.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use consts::RuntimeInfos;
 pub use events::EventHub;
 pub use logger::Logger;
-pub use manager_bridge::CoreManagerService as CoreManager;
+pub use manager_bridge::{CoreManagerService as CoreManager, ServiceDirs};
 use nyanpasu_core_manager::{ExecutorExit, LocalIpcPolicy};
 use nyanpasu_ipc::{SERVICE_PLACEHOLDER, server::create_server};
 use routing::{AppState, create_router};
@@ -31,7 +31,14 @@ pub async fn run(
             .map_err(|path| anyhow::anyhow!("core runtime dir is not UTF-8: {}", path.display()))?;
     let data_dir = camino::Utf8PathBuf::from_path_buf(runtime.nyanpasu_data_dir.clone())
         .map_err(|path| anyhow::anyhow!("nyanpasu data dir is not UTF-8: {}", path.display()))?;
-    let core_manager = CoreManager::new(runtime_dir, local_ipc_policy, data_dir).await?;
+    let core_manager = CoreManager::new(
+        ServiceDirs {
+            runtime: runtime_dir,
+            data: data_dir,
+        },
+        local_ipc_policy,
+    )
+    .await?;
     let hub = EventHub::new();
     core_manager.spawn_bridges(hub.clone());
 

--- a/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
@@ -31,7 +31,7 @@ use tempfile::TempDir;
 use tower::ServiceExt;
 
 use super::{AppState, create_router};
-use crate::server::{CoreManager, EventHub, Logger, consts::RuntimeInfos};
+use crate::server::{CoreManager, EventHub, Logger, ServiceDirs, consts::RuntimeInfos};
 
 struct TestEnv {
     state: AppState,
@@ -46,9 +46,15 @@ impl TestEnv {
             Utf8PathBuf::from_path_buf(root.join("core-runtime")).expect("temp path is UTF-8");
         let data_dir =
             Utf8PathBuf::from_path_buf(root.join("nyanpasu-data")).expect("temp path is UTF-8");
-        let core_manager = CoreManager::new(runtime_dir, LocalIpcPolicy::Disable, data_dir)
-            .await
-            .unwrap();
+        let core_manager = CoreManager::new(
+            ServiceDirs {
+                runtime: runtime_dir,
+                data: data_dir,
+            },
+            LocalIpcPolicy::Disable,
+        )
+        .await
+        .unwrap();
         let runtime = Arc::new(RuntimeInfos {
             service_data_dir: root.join("service-data"),
             service_config_dir: root.join("service-config"),


### PR DESCRIPTION
Removes four *signature transposition* defects in `nyanpasu-service-runtime` and
`clash-api`: call sites where two same-typed parameters can be swapped, still
compile, still run, and produce a wrong result that nothing reports.

Each commit replaces positional same-typed parameters with a named struct. No
behaviour changes.

| Commit | Before | After |
|---|---|---|
| `name runtime and data directories` | `CoreManagerService::new(runtime_dir, policy, data_dir)` — two `Utf8PathBuf` split by the policy | `new(ServiceDirs { runtime, data }, policy)` |
| `name install program and working directory` | `build_install_ctx(label, program, working_directory, ctx, env)` | `InstallPaths { program, working_directory }` |
| `take retry delay bounds by name` | `ExponentialRetry::new(max_retries, min_delay, max_delay)` | `new(max_retries, DelayRange { min, max })` |
| `select proxies through a named selection` | `select_proxy(group, target)` — both `&ProxyName` | `select_proxy(ProxySelection { group, target })` |

## Why these

`build_install_ctx` is the one that persists. The swapped pair goes straight
into `ServiceInstallCtx` and is written to the OS service manager's stored
definition — the daemon registered to execute a directory and run out of its own
binary. Nothing in the install path compares either value against the role it
was passed for.

`select_proxy` is the case where a newtype guards the wrong boundary:
`ProxyName` separates a proxy name from any other string, but a group and a node
inside it are the same type, so a transposition compiles and is sent.

## Notes

- Two `pub` signatures change (hence `!` on both `clash-api` commits).
  `nyanpasu-runtime` is the only consumer and every in-tree call site is
  updated.
- `ExponentialRetry::new` gains a **`debug_assert!`** on the range order, not an
  `assert!`. It is a public `const fn`, and a release-build panic would reject
  inverted bounds that the previous signature accepted and `backon` still
  schedules.
- `ProxySelection` rather than splitting `ProxyName` into group and node
  newtypes: the split would prevent this at the type level but touch every
  proxy-facing method on the public surface, for the one call that takes both at
  once.
- `ControlOptions::new(source_dir, data_dir)` at `manager_bridge.rs:198` is still
  positional. Its declaration lives in `nyanpasu-core-manager`, outside these
  crates; it is wired correctly here and left for that crate.

## Verification

`cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets
--all-features` are clean (one pre-existing `unused variable: debug` warning in
`logging.rs`). `cargo test --workspace --all-features`: 40 test targets, 455
passed, 0 failed.

`git diff` touches no IPC message shape, no HTTP route, and no CLI argument. For
identical inputs `select_proxy` still emits a byte-identical PUT path and body.

`install.rs` has `cfg(target_os = "linux")` / `cfg(not(windows))` branches around
the two paths, and its test module is already `cfg(not(target_os = "macos"))`;
the change itself sits outside every one of those blocks.

https://claude.ai/code/session_01BsiU6nsZN2i4fcNntm2xZd
