### PR TITLE
chore(submodule): bump nyanpasu-utils onto its named-input signatures

### DIFF
--- a/crates/nyanpasu-core-manager/README.md
+++ b/crates/nyanpasu-core-manager/README.md
@@ -498,7 +498,7 @@ use std::num::NonZeroU32;
 use nyanpasu_core_manager::{
     HealthPolicy, HealthPolicySpec, HealthThresholds, InstanceOptions,
 };
-use nyanpasu_utils::process::{Backoff, RestartPolicy};
+use nyanpasu_utils::process::{Backoff, BackoffRange, RestartPolicy};
 
 let options = InstanceOptions {
     // Total budget for the initial start, crash retries included.
@@ -513,8 +513,11 @@ let options = InstanceOptions {
         start_period: Duration::ZERO,         // failure grace per child run
     })?,
     restart_policy: RestartPolicy::OnFailure { max_restarts: 5 },
-    backoff: Backoff::exponential(Duration::from_secs(1), Duration::from_secs(30))
-        .with_jitter(),
+    backoff: Backoff::exponential(BackoffRange {
+        initial: Duration::from_secs(1),
+        max: Duration::from_secs(30),
+    })
+    .with_jitter(),
 };
 ```
 

--- a/crates/nyanpasu-core-manager/src/config/runtime_store.rs
+++ b/crates/nyanpasu-core-manager/src/config/runtime_store.rs
@@ -241,7 +241,11 @@ impl RuntimeConfigStore {
         self.validate_staged(&staged, epoch).await?;
         let target = self.runtime_path(epoch);
         atomic_fs::validate_existing_regular_target(&target).await?;
-        atomic_fs::atomic_replace(&staged.path, &target).await?;
+        atomic_fs::atomic_replace(atomic_fs::AtomicReplacement {
+            replacement: staged.path.as_std_path(),
+            destination: target.as_std_path(),
+        })
+        .await?;
         staged.consumed = true;
         #[cfg(feature = "test-hooks")]
         let injected_failure = self

--- a/crates/nyanpasu-core-manager/src/instance.rs
+++ b/crates/nyanpasu-core-manager/src/instance.rs
@@ -9,8 +9,8 @@ use std::{
 };
 
 use nyanpasu_utils::process::{
-    Command, EpochPidFile, OrphanReapOutcome, ProcessError, ProcessEvent, ReadinessProbe,
-    Supervisor, SupervisorEvent, TerminatedPayload, reap_epoch_pid_file,
+    Command, EpochPidFile, EpochPidFileSpec, OrphanReapOutcome, ProcessError, ProcessEvent,
+    ReadinessProbe, Supervisor, SupervisorEvent, TerminatedPayload, reap_epoch_pid_file,
 };
 use tokio::{
     sync::{broadcast, mpsc, oneshot, watch},
@@ -518,11 +518,11 @@ fn build_command(spec: &InstanceSpec, epoch: Epoch, controller: &ResolvedControl
         .current_dir(spec.working_dir.as_str());
     if let Some(pid_file) = &spec.pid_file {
         command = if epoch_pid_path(spec, epoch).is_some() {
-            command.epoch_pid_file(EpochPidFile::new(
-                pid_file.as_std_path(),
-                epoch.get(),
-                spec.config_path.as_std_path(),
-            ))
+            command.epoch_pid_file(EpochPidFile::new(EpochPidFileSpec {
+                pid_path: pid_file.as_std_path(),
+                runtime_config: spec.config_path.as_std_path(),
+                epoch: epoch.get(),
+            }))
         } else {
             command.pid_file(pid_file.as_std_path())
         };

--- a/crates/nyanpasu-core-manager/src/manager/dns_sync.rs
+++ b/crates/nyanpasu-core-manager/src/manager/dns_sync.rs
@@ -231,7 +231,11 @@ impl CoreManager {
                     // "absent": we cannot publish safely into a directory we
                     // cannot stat.
                     if tokio::fs::try_exists(&path).await? {
-                        atomic_fs::atomic_replace(&staging, &path).await
+                        atomic_fs::atomic_replace(atomic_fs::AtomicReplacement {
+                            replacement: staging.as_std_path(),
+                            destination: path.as_std_path(),
+                        })
+                        .await
                     } else {
                         atomic_fs::atomic_move_new(&staging, &path).await
                     }

--- a/crates/nyanpasu-core-manager/src/spec.rs
+++ b/crates/nyanpasu-core-manager/src/spec.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use camino::Utf8PathBuf;
-use nyanpasu_utils::process::{Backoff, RestartPolicy};
+use nyanpasu_utils::process::{Backoff, BackoffRange, RestartPolicy};
 use tokio_util::sync::CancellationToken;
 
 use crate::{health::HealthPolicy, kind::CoreKind};
@@ -52,8 +52,11 @@ impl Default for InstanceOptions {
             startup_timeout: Duration::from_secs(30),
             health: HealthPolicy::default(),
             restart_policy: RestartPolicy::OnFailure { max_restarts: 5 },
-            backoff: Backoff::exponential(Duration::from_secs(1), Duration::from_secs(30))
-                .with_jitter(),
+            backoff: Backoff::exponential(BackoffRange {
+                initial: Duration::from_secs(1),
+                max: Duration::from_secs(30),
+            })
+            .with_jitter(),
         }
     }
 }

--- a/crates/nyanpasu-core-manager/tests/common/mod.rs
+++ b/crates/nyanpasu-core-manager/tests/common/mod.rs
@@ -12,7 +12,7 @@ use nyanpasu_core_manager::{
     InstanceSpec,
     state::{HealthState, InstanceState, InstanceStatus},
 };
-use nyanpasu_utils::process::{Backoff, RestartPolicy};
+use nyanpasu_utils::process::{Backoff, BackoffRange, RestartPolicy};
 use parking_lot::Mutex;
 use tokio::sync::watch;
 
@@ -51,7 +51,10 @@ pub fn fast_options() -> InstanceOptions {
         })
         .unwrap(),
         restart_policy: RestartPolicy::OnFailure { max_restarts: 2 },
-        backoff: Backoff::exponential(Duration::from_millis(50), Duration::from_millis(200)),
+        backoff: Backoff::exponential(BackoffRange {
+            initial: Duration::from_millis(50),
+            max: Duration::from_millis(200),
+        }),
     }
 }
 

--- a/crates/nyanpasu-core-manager/tests/graceful_switch.rs
+++ b/crates/nyanpasu-core-manager/tests/graceful_switch.rs
@@ -825,10 +825,11 @@ async fn failed_new_core_while_old_restarting_republishes_actual_state() {
     .await
     .expect("construct manager");
     let mut spec_a = common::mihomo_spec(&dir, config_a);
-    spec_a.options.backoff = nyanpasu_utils::process::Backoff::exponential(
-        Duration::from_secs(60),
-        Duration::from_secs(60),
-    );
+    spec_a.options.backoff =
+        nyanpasu_utils::process::Backoff::exponential(nyanpasu_utils::process::BackoffRange {
+            initial: Duration::from_secs(60),
+            max: Duration::from_secs(60),
+        });
     let mut rx = manager.subscribe();
 
     manager.start(spec_a).await.expect("start A");

--- a/crates/nyanpasu-core-manager/tests/instance_lifecycle.rs
+++ b/crates/nyanpasu-core-manager/tests/instance_lifecycle.rs
@@ -654,10 +654,11 @@ async fn startup_timeout_is_one_budget_across_crash_retries() {
     spec.options.startup_timeout = Duration::from_secs(10);
     spec.options.restart_policy =
         nyanpasu_utils::process::RestartPolicy::OnFailure { max_restarts: 20 };
-    spec.options.backoff = nyanpasu_utils::process::Backoff::exponential(
-        Duration::from_millis(10),
-        Duration::from_millis(10),
-    );
+    spec.options.backoff =
+        nyanpasu_utils::process::Backoff::exponential(nyanpasu_utils::process::BackoffRange {
+            initial: Duration::from_millis(10),
+            max: Duration::from_millis(10),
+        });
     let instance = Instance::builder(
         spec,
         common::epoch(1),


### PR DESCRIPTION
Follow-through for [nyanpasu-utils#182](https://github.com/LibNyanpasu/nyanpasu-utils/pull/182): that PR replaced the transposable positional parameters of three utils APIs with named views, so this repo's pin cannot move without its call sites moving in the same commit.

## The pin

`crates/nyanpasu-utils` 3cb3af0 → 2071ee5 (utils `main`). The pin was ten commits behind, so the bump also carries eight renovate dependency updates and a rustfmt pass; none of them touch an API this repo uses.

## Call sites

| Old | New | Sites |
|---|---|---|
| `atomic_replace(source, target)` | `atomic_replace(AtomicReplacement { replacement, destination })` | `config/runtime_store.rs`, `manager/dns_sync.rs` |
| `EpochPidFile::new(path, epoch, runtime_config)` | `EpochPidFile::new(EpochPidFileSpec { pid_path, runtime_config, epoch })` | `instance.rs` |
| `Backoff::exponential(initial, max)` | `Backoff::exponential(BackoffRange { initial, max })` | `spec.rs` + three test sites |

`EpochPidFile::new` is the one that mattered: its two paths sat either side of the epoch, and this crate is its only caller.

`atomic_replace` narrowed from `impl AsRef<Path>` to `&Path` as part of taking a borrowed view, so the two publish sites now convert explicitly — `Utf8PathBuf` no longer coerces at the boundary. `atomic_move_new` kept the generic signature, which is why the `else` arm beside it in the DNS record publish is unchanged.

The README's `InstanceOptions` example is updated with the rest; it is not doctested (no `include_str!` in `lib.rs`), so nothing but a reader would have caught it.

## Verification

- `cargo fmt --all` clean; `cargo clippy --workspace --all-targets --all-features` clean apart from the pre-existing `unused variable: debug` in `nyanpasu-service-runtime/src/logging.rs`
- `cargo test --workspace --all-features`: 46 targets, 485 passed, 0 failed
- Each migrated site was checked against the *old* positional order rather than the new field names, and independently re-checked by a codex review pass — a silent swap here is the exact defect the utils refactor exists to prevent
- Windows-local only for the cross-target step: this workspace cannot cross-compile (`aws-lc-sys` needs a Linux C toolchain), but no changed line sits inside a `cfg` block, and `atomic_replace`'s platform split lives in utils, which has its own CI

## Scope

This is step U4 of the signature-transposition plan, after utils #182, #397 and #398. W3 (main repo) stays blocked on its own preconditions and is untouched here.

Left alone deliberately: `docs/superpowers/plans/2026-07-17…`, `2026-07-18…` and `specs/2026-07-16…` still show the positional `Backoff::exponential`. Those are dated planning snapshots — records of what the design was on those days — so editing them would falsify the record rather than fix a doc.

https://claude.ai/code/session_01BsiU6nsZN2i4fcNntm2xZd
